### PR TITLE
proxmox & gitea mirror

### DIFF
--- a/.github/workflows/mirror-gitea.yml
+++ b/.github/workflows/mirror-gitea.yml
@@ -1,0 +1,48 @@
+name: Mirror to Gitea
+
+on:
+  push:
+    branches: ["**"]
+    tags: ["**"]
+  delete:
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Add Gitea remote
+        run: git remote add gitea https://${{ secrets.GITEA_USERNAME }}:${{ secrets.GITEA_TOKEN }}@gitea.com/kicka5h/gecko-iac.git
+
+      - name: Fetch Gitea state
+        run: git fetch gitea main --quiet 2>/dev/null || echo "Gitea main not found (first mirror)"
+
+      - name: Diff check (GitHub main vs Gitea main)
+        run: |
+          if git rev-parse gitea/main >/dev/null 2>&1; then
+            BEHIND=$(git rev-list --count gitea/main..origin/main)
+            AHEAD=$(git rev-list --count origin/main..gitea/main)
+            if [ "$BEHIND" -eq 0 ] && [ "$AHEAD" -eq 0 ]; then
+              echo "✓ Gitea main is in sync with GitHub main"
+            else
+              echo "⚠ Gitea main is out of sync:"
+              echo "  GitHub is $BEHIND commit(s) ahead of Gitea"
+              echo "  Gitea is $AHEAD commit(s) ahead of GitHub (will be overwritten)"
+              echo ""
+              echo "Commits to push:"
+              git log --oneline gitea/main..origin/main || true
+              echo ""
+              echo "Commits on Gitea not on GitHub (will be lost):"
+              git log --oneline origin/main..gitea/main || true
+            fi
+          else
+            echo "→ First mirror — no Gitea main to compare"
+          fi
+
+      - name: Push to Gitea
+        run: |
+          git push gitea --all --force
+          git push gitea --tags --force

--- a/providers/foss/proxmox.go
+++ b/providers/foss/proxmox.go
@@ -43,6 +43,76 @@ type proxmoxAPI interface {
 	UpdateNetwork(ctx context.Context, iface string, cfg NetworkConfig) error
 	DeleteNetwork(ctx context.Context, iface string) error
 	ReloadNetwork(ctx context.Context) error
+
+	CreateFirewallRule(ctx context.Context, scope string, rule FirewallRuleInfo) (int, error)
+	ReadFirewallRule(ctx context.Context, scope string, pos int) (*FirewallRuleInfo, error)
+	UpdateFirewallRule(ctx context.Context, scope string, pos int, rule FirewallRuleInfo) error
+	DeleteFirewallRule(ctx context.Context, scope string, pos int) error
+
+	CreateSnapshot(ctx context.Context, vmid int, name, description string, vmstate bool) error
+	ReadSnapshot(ctx context.Context, vmid int, name string) (*SnapshotInfo, error)
+	DeleteSnapshot(ctx context.Context, vmid int, name string) error
+
+	CreatePool(ctx context.Context, poolid, comment string) error
+	ReadPool(ctx context.Context, poolid string) (*PoolInfo, error)
+	UpdatePool(ctx context.Context, poolid, comment string) error
+	DeletePool(ctx context.Context, poolid string) error
+
+	CreateBackupJob(ctx context.Context, job BackupJobInfo) (string, error)
+	ReadBackupJob(ctx context.Context, id string) (*BackupJobInfo, error)
+	UpdateBackupJob(ctx context.Context, id string, job BackupJobInfo) error
+	DeleteBackupJob(ctx context.Context, id string) error
+
+	// SDN
+	CreateSDNZone(ctx context.Context, zone SDNZoneInfo) error
+	ReadSDNZone(ctx context.Context, zone string) (*SDNZoneInfo, error)
+	UpdateSDNZone(ctx context.Context, zone string, info SDNZoneInfo) error
+	DeleteSDNZone(ctx context.Context, zone string) error
+
+	CreateSDNVnet(ctx context.Context, vnet SDNVnetInfo) error
+	ReadSDNVnet(ctx context.Context, vnet string) (*SDNVnetInfo, error)
+	UpdateSDNVnet(ctx context.Context, vnet string, info SDNVnetInfo) error
+	DeleteSDNVnet(ctx context.Context, vnet string) error
+
+	CreateSDNSubnet(ctx context.Context, vnet string, subnet SDNSubnetInfo) error
+	ReadSDNSubnet(ctx context.Context, vnet, subnet string) (*SDNSubnetInfo, error)
+	UpdateSDNSubnet(ctx context.Context, vnet, subnet string, info SDNSubnetInfo) error
+	DeleteSDNSubnet(ctx context.Context, vnet, subnet string) error
+
+	// HA
+	CreateHAGroup(ctx context.Context, group HAGroupInfo) error
+	ReadHAGroup(ctx context.Context, group string) (*HAGroupInfo, error)
+	UpdateHAGroup(ctx context.Context, group string, info HAGroupInfo) error
+	DeleteHAGroup(ctx context.Context, group string) error
+
+	CreateHAResource(ctx context.Context, res HAResourceInfo) error
+	ReadHAResource(ctx context.Context, sid string) (*HAResourceInfo, error)
+	UpdateHAResource(ctx context.Context, sid string, info HAResourceInfo) error
+	DeleteHAResource(ctx context.Context, sid string) error
+
+	// ACME
+	CreateACMEAccount(ctx context.Context, acct ACMEAccountInfo) error
+	ReadACMEAccount(ctx context.Context, name string) (*ACMEAccountInfo, error)
+	DeleteACMEAccount(ctx context.Context, name string) error
+
+	// Users/Roles/ACLs
+	CreateUser(ctx context.Context, user PVEUserInfo) error
+	ReadUser(ctx context.Context, userid string) (*PVEUserInfo, error)
+	UpdateUser(ctx context.Context, userid string, user PVEUserInfo) error
+	DeleteUser(ctx context.Context, userid string) error
+
+	CreateRole(ctx context.Context, role PVERoleInfo) error
+	ReadRole(ctx context.Context, roleid string) (*PVERoleInfo, error)
+	UpdateRole(ctx context.Context, roleid string, role PVERoleInfo) error
+	DeleteRole(ctx context.Context, roleid string) error
+
+	SetACL(ctx context.Context, acl PVEACLInfo) error
+	ReadACL(ctx context.Context, path string) (*PVEACLInfo, error)
+	DeleteACL(ctx context.Context, path string) error
+
+	// Cluster
+	ReadClusterOptions(ctx context.Context) (*ClusterOptionsInfo, error)
+	UpdateClusterOptions(ctx context.Context, opts ClusterOptionsInfo) error
 }
 
 // ── Value types returned by the interface (no library type leakage) ────────────
@@ -182,6 +252,142 @@ type NetworkConfig struct {
 	Gateway6        string
 }
 
+// FirewallRuleInfo holds a single Proxmox firewall rule.
+type FirewallRuleInfo struct {
+	Pos     int
+	Type    string // "in" or "out"
+	Action  string // ACCEPT, DROP, REJECT
+	Source  string
+	Dest    string
+	Proto   string
+	DPort   string
+	SPort   string
+	Enable  bool
+	Comment string
+	Log     string
+	Macro   string
+	Iface   string
+}
+
+// SnapshotInfo holds a VM/CT snapshot.
+type SnapshotInfo struct {
+	Name        string
+	Description string
+	VMState     bool
+}
+
+// PoolInfo holds a Proxmox resource pool.
+type PoolInfo struct {
+	PoolID  string
+	Comment string
+}
+
+// BackupJobInfo holds a Proxmox backup job configuration.
+type BackupJobInfo struct {
+	ID           string
+	VMID         string // VM/CT ID or "all"
+	Storage      string
+	Mode         string // snapshot, suspend, stop
+	Compress     string // zstd, lzo, gzip, 0
+	Mailto       string
+	Schedule     string
+	Enabled      bool
+	PruneBackups string
+}
+
+// SDNZoneInfo holds a Proxmox SDN zone.
+type SDNZoneInfo struct {
+	Zone       string
+	Type       string // simple, vlan, qinq, vxlan, evpn
+	Bridge     string
+	MTU        int
+	Nodes      string
+	DNS        string
+	ReverseDNS string
+	DNSZone    string
+	IPAM       string
+}
+
+// SDNVnetInfo holds a Proxmox SDN virtual network.
+type SDNVnetInfo struct {
+	Vnet      string
+	Zone      string
+	Tag       int
+	Alias     string
+	VlanAware bool
+}
+
+// SDNSubnetInfo holds a Proxmox SDN subnet.
+type SDNSubnetInfo struct {
+	Subnet        string // CIDR
+	Vnet          string
+	Gateway       string
+	SNAT          bool
+	DNSZonePrefix string
+}
+
+// HAGroupInfo holds a Proxmox HA group.
+type HAGroupInfo struct {
+	Group      string
+	Nodes      string // e.g. "node1:2,node2:1"
+	Restricted bool
+	NoFailback bool
+	Comment    string
+}
+
+// HAResourceInfo holds a Proxmox HA resource.
+type HAResourceInfo struct {
+	SID          string // e.g. "vm:100", "ct:101"
+	Group        string
+	MaxRelocate  int
+	MaxRestart   int
+	State        string // started, stopped, disabled
+	Comment      string
+}
+
+// ACMEAccountInfo holds a Proxmox ACME account.
+type ACMEAccountInfo struct {
+	Name      string
+	Contact   string
+	Directory string
+}
+
+// PVEUserInfo holds a Proxmox user.
+type PVEUserInfo struct {
+	UserID    string // e.g. "user@pam"
+	Email     string
+	FirstName string
+	LastName  string
+	Groups    string
+	Enable    bool
+	Expire    int
+	Comment   string
+}
+
+// PVERoleInfo holds a Proxmox role.
+type PVERoleInfo struct {
+	RoleID string
+	Privs  string
+}
+
+// PVEACLInfo holds a Proxmox ACL entry.
+type PVEACLInfo struct {
+	Path      string
+	Roles     string
+	Users     string
+	Groups    string
+	Propagate bool
+}
+
+// ClusterOptionsInfo holds Proxmox cluster-wide options.
+type ClusterOptionsInfo struct {
+	Keyboard        string
+	Language         string
+	EmailFrom       string
+	MigrationType   string
+	MigrationNetwork string
+}
+
 // ── ProxmoxProvider ───────────────────────────────────────────────────────────
 
 // ProxmoxProvider manages Proxmox VE resources via the PVE REST API.
@@ -228,6 +434,20 @@ func (p *ProxmoxProvider) SupportedTypes() []core.ResourceType {
 		"proxmox:lxc",
 		"proxmox:storage",
 		"proxmox:network",
+		"proxmox:firewall_rule",
+		"proxmox:snapshot",
+		"proxmox:pool",
+		"proxmox:backup",
+		"proxmox:sdn_zone",
+		"proxmox:sdn_vnet",
+		"proxmox:sdn_subnet",
+		"proxmox:ha_group",
+		"proxmox:ha_resource",
+		"proxmox:acme_account",
+		"proxmox:user",
+		"proxmox:role",
+		"proxmox:acl",
+		"proxmox:cluster_options",
 	}
 }
 
@@ -293,6 +513,34 @@ func (p *ProxmoxProvider) Create(ctx context.Context, args core.ResourceArgs) (*
 		return p.createStorage(ctx, args)
 	case "proxmox:network":
 		return p.createNetwork(ctx, args)
+	case "proxmox:firewall_rule":
+		return p.createFirewallRule(ctx, args)
+	case "proxmox:snapshot":
+		return p.createSnapshot(ctx, args)
+	case "proxmox:pool":
+		return p.createPool(ctx, args)
+	case "proxmox:backup":
+		return p.createBackupJob(ctx, args)
+	case "proxmox:sdn_zone":
+		return p.createSDNZone(ctx, args)
+	case "proxmox:sdn_vnet":
+		return p.createSDNVnet(ctx, args)
+	case "proxmox:sdn_subnet":
+		return p.createSDNSubnet(ctx, args)
+	case "proxmox:ha_group":
+		return p.createHAGroup(ctx, args)
+	case "proxmox:ha_resource":
+		return p.createHAResource(ctx, args)
+	case "proxmox:acme_account":
+		return p.createACMEAccount(ctx, args)
+	case "proxmox:user":
+		return p.createUser(ctx, args)
+	case "proxmox:role":
+		return p.createRole(ctx, args)
+	case "proxmox:acl":
+		return p.createACL(ctx, args)
+	case "proxmox:cluster_options":
+		return p.createClusterOptions(ctx, args)
 	default:
 		return nil, fmt.Errorf("proxmox: unsupported resource type %q", args.Type)
 	}
@@ -316,6 +564,34 @@ func (p *ProxmoxProvider) Read(ctx context.Context, id core.ResourceID, external
 		return p.readStorage(ctx, id, externalID)
 	case "proxmox:network":
 		return p.readNetwork(ctx, id, externalID)
+	case "proxmox:firewall_rule":
+		return p.readFirewallRule(ctx, id, externalID)
+	case "proxmox:snapshot":
+		return p.readSnapshot(ctx, id, externalID)
+	case "proxmox:pool":
+		return p.readPool(ctx, id, externalID)
+	case "proxmox:backup":
+		return p.readBackupJob(ctx, id, externalID)
+	case "proxmox:sdn_zone":
+		return p.readSDNZoneRes(ctx, id, externalID)
+	case "proxmox:sdn_vnet":
+		return p.readSDNVnetRes(ctx, id, externalID)
+	case "proxmox:sdn_subnet":
+		return p.readSDNSubnetRes(ctx, id, externalID)
+	case "proxmox:ha_group":
+		return p.readHAGroupRes(ctx, id, externalID)
+	case "proxmox:ha_resource":
+		return p.readHAResourceRes(ctx, id, externalID)
+	case "proxmox:acme_account":
+		return p.readACMEAccountRes(ctx, id, externalID)
+	case "proxmox:user":
+		return p.readUserRes(ctx, id, externalID)
+	case "proxmox:role":
+		return p.readRoleRes(ctx, id, externalID)
+	case "proxmox:acl":
+		return p.readACLRes(ctx, id, externalID)
+	case "proxmox:cluster_options":
+		return p.readClusterOptionsRes(ctx, id, externalID)
 	default:
 		return nil, fmt.Errorf("proxmox: unsupported resource type %q", rType)
 	}
@@ -334,6 +610,32 @@ func (p *ProxmoxProvider) Update(ctx context.Context, current *core.ResourceStat
 		return p.updateStorage(ctx, current, desired)
 	case "proxmox:network":
 		return p.updateNetwork(ctx, current, desired)
+	case "proxmox:firewall_rule":
+		return p.updateFirewallRule(ctx, current, desired)
+	case "proxmox:pool":
+		return p.updatePool(ctx, current, desired)
+	case "proxmox:backup":
+		return p.updateBackupJob(ctx, current, desired)
+	case "proxmox:snapshot":
+		return nil, fmt.Errorf("proxmox: snapshots are immutable — delete and recreate")
+	case "proxmox:sdn_zone":
+		return p.updateSDNZoneRes(ctx, current, desired)
+	case "proxmox:sdn_vnet":
+		return p.updateSDNVnetRes(ctx, current, desired)
+	case "proxmox:sdn_subnet":
+		return p.updateSDNSubnetRes(ctx, current, desired)
+	case "proxmox:ha_group":
+		return p.updateHAGroupRes(ctx, current, desired)
+	case "proxmox:ha_resource":
+		return p.updateHAResourceRes(ctx, current, desired)
+	case "proxmox:user":
+		return p.updateUserRes(ctx, current, desired)
+	case "proxmox:role":
+		return p.updateRoleRes(ctx, current, desired)
+	case "proxmox:cluster_options":
+		return p.updateClusterOptionsRes(ctx, current, desired)
+	case "proxmox:acme_account", "proxmox:acl":
+		return nil, fmt.Errorf("proxmox: %s is immutable — delete and recreate", desired.Type)
 	default:
 		return nil, fmt.Errorf("proxmox: unsupported resource type %q", desired.Type)
 	}
@@ -352,6 +654,38 @@ func (p *ProxmoxProvider) Delete(ctx context.Context, state *core.ResourceState)
 		return p.deleteStorage(ctx, state)
 	case "proxmox:network":
 		return p.deleteNetwork(ctx, state)
+	case "proxmox:firewall_rule":
+		return p.deleteFirewallRule(ctx, state)
+	case "proxmox:snapshot":
+		return p.deleteSnapshot(ctx, state)
+	case "proxmox:pool":
+		return p.deletePool(ctx, state)
+	case "proxmox:backup":
+		return p.deleteBackupJob(ctx, state)
+	case "proxmox:sdn_zone":
+		return p.api.DeleteSDNZone(ctx, state.ExternalID)
+	case "proxmox:sdn_vnet":
+		return p.api.DeleteSDNVnet(ctx, state.ExternalID)
+	case "proxmox:sdn_subnet":
+		parts := strings.SplitN(state.ExternalID, "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("proxmox: invalid sdn_subnet externalID %q", state.ExternalID)
+		}
+		return p.api.DeleteSDNSubnet(ctx, parts[0], parts[1])
+	case "proxmox:ha_group":
+		return p.api.DeleteHAGroup(ctx, state.ExternalID)
+	case "proxmox:ha_resource":
+		return p.api.DeleteHAResource(ctx, state.ExternalID)
+	case "proxmox:acme_account":
+		return p.api.DeleteACMEAccount(ctx, state.ExternalID)
+	case "proxmox:user":
+		return p.api.DeleteUser(ctx, state.ExternalID)
+	case "proxmox:role":
+		return p.api.DeleteRole(ctx, state.ExternalID)
+	case "proxmox:acl":
+		return p.api.DeleteACL(ctx, state.ExternalID)
+	case "proxmox:cluster_options":
+		return nil // cluster options cannot be deleted, only updated
 	default:
 		return fmt.Errorf("proxmox: unsupported resource type %q", state.Type)
 	}
@@ -417,6 +751,64 @@ func (p *ProxmoxProvider) Diff(ctx context.Context, current *core.ResourceState,
 			"bond_mode", "bond_primary",
 			"address", "netmask", "address6", "gateway6",
 		} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:firewall_rule":
+		for _, f := range []string{
+			"type", "action", "source", "dest", "proto",
+			"dport", "sport", "enable", "comment", "log", "macro", "iface",
+		} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:snapshot":
+		for _, f := range []string{"description", "vmstate"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:pool":
+		changes = append(changes, compareField("comment", current.Inputs, desired.Inputs)...)
+	case "proxmox:backup":
+		for _, f := range []string{
+			"vmid", "storage", "mode", "compress",
+			"mailto", "schedule", "enabled", "prune_backups",
+		} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:sdn_zone":
+		for _, f := range []string{"type", "bridge", "mtu", "nodes", "dns", "reversedns", "dnszone", "ipam"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:sdn_vnet":
+		for _, f := range []string{"zone", "tag", "alias", "vlanaware"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:sdn_subnet":
+		for _, f := range []string{"gateway", "snat", "dnszoneprefix"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:ha_group":
+		for _, f := range []string{"nodes", "restricted", "nofailback", "comment"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:ha_resource":
+		for _, f := range []string{"group", "max_relocate", "max_restart", "state", "comment"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:acme_account":
+		for _, f := range []string{"contact", "directory"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:user":
+		for _, f := range []string{"email", "firstname", "lastname", "groups", "enable", "expire", "comment"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:role":
+		changes = append(changes, compareField("privs", current.Inputs, desired.Inputs)...)
+	case "proxmox:acl":
+		for _, f := range []string{"roles", "users", "groups", "propagate"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
+	case "proxmox:cluster_options":
+		for _, f := range []string{"keyboard", "language", "email_from", "migration_type", "migration_network"} {
 			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
 		}
 	}
@@ -1154,4 +1546,691 @@ func splitNetworkID(externalID string) (nodeName, iface string, err error) {
 		return "", "", fmt.Errorf("proxmox: invalid network externalID %q (expected <node>/<iface>)", externalID)
 	}
 	return externalID[:idx], externalID[idx+1:], nil
+}
+
+// ── Firewall rule resource handlers ─────────────────────────────────────────
+
+func firewallRuleFromInputs(inputs core.Inputs) FirewallRuleInfo {
+	getString := func(k string) string { v, _ := inputs[k].(string); return v }
+	getBool := func(k string) bool { v, _ := inputs[k].(bool); return v }
+	return FirewallRuleInfo{
+		Type:    getString("type"),
+		Action:  getString("action"),
+		Source:  getString("source"),
+		Dest:    getString("dest"),
+		Proto:   getString("proto"),
+		DPort:   getString("dport"),
+		SPort:   getString("sport"),
+		Enable:  getBool("enable"),
+		Comment: getString("comment"),
+		Log:     getString("log"),
+		Macro:   getString("macro"),
+		Iface:   getString("iface"),
+	}
+}
+
+// firewallScope returns the API scope path for a firewall rule.
+// Cluster-level if no node/vmid, node-level if node set, VM-level if vmid set.
+func firewallScope(inputs core.Inputs, node string) string {
+	if vmid, ok := toInt(inputs["vmid"]); ok && vmid > 0 {
+		return fmt.Sprintf("%s/%d", node, vmid)
+	}
+	if n, ok := inputs["node"].(string); ok && n != "" {
+		return n
+	}
+	return "cluster"
+}
+
+func (p *ProxmoxProvider) createFirewallRule(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	scope := firewallScope(args.Inputs, p.node)
+	rule := firewallRuleFromInputs(args.Inputs)
+
+	pos, err := p.api.CreateFirewallRule(ctx, scope, rule)
+	if err != nil {
+		return nil, fmt.Errorf("proxmox: create firewall rule %q: %w", args.Name, err)
+	}
+
+	return &core.ResourceState{
+		ID:         proxmoxResourceID(args),
+		Type:       args.Type,
+		Name:       args.Name,
+		Status:     core.StatusRunning,
+		Inputs:     args.Inputs,
+		Outputs:    core.Outputs{"pos": pos, "scope": scope},
+		ExternalID: fmt.Sprintf("%s/%d", scope, pos),
+		ProviderID: "proxmox",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) readFirewallRule(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	// externalID format: "<scope>/<pos>"
+	idx := strings.LastIndex(externalID, "/")
+	if idx <= 0 {
+		return nil, fmt.Errorf("proxmox: invalid firewall rule externalID %q", externalID)
+	}
+	scope := externalID[:idx]
+	pos, err := strconv.Atoi(externalID[idx+1:])
+	if err != nil {
+		return nil, fmt.Errorf("proxmox: invalid firewall rule pos in %q: %w", externalID, err)
+	}
+
+	info, err := p.api.ReadFirewallRule(ctx, scope, pos)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil {
+		return nil, nil
+	}
+
+	inputs := core.Inputs{
+		"type":   info.Type,
+		"action": info.Action,
+		"enable": info.Enable,
+	}
+	setIfNonEmpty := func(k, v string) { if v != "" { inputs[k] = v } }
+	setIfNonEmpty("source", info.Source)
+	setIfNonEmpty("dest", info.Dest)
+	setIfNonEmpty("proto", info.Proto)
+	setIfNonEmpty("dport", info.DPort)
+	setIfNonEmpty("sport", info.SPort)
+	setIfNonEmpty("comment", info.Comment)
+	setIfNonEmpty("log", info.Log)
+	setIfNonEmpty("macro", info.Macro)
+	setIfNonEmpty("iface", info.Iface)
+
+	return &core.ResourceState{
+		ID:         id,
+		Type:       "proxmox:firewall_rule",
+		ExternalID: externalID,
+		ProviderID: "proxmox",
+		Status:     core.StatusRunning,
+		Inputs:     inputs,
+		Outputs:    core.Outputs{"pos": pos, "scope": scope},
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) updateFirewallRule(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	idx := strings.LastIndex(current.ExternalID, "/")
+	if idx <= 0 {
+		return nil, fmt.Errorf("proxmox: invalid firewall rule externalID %q", current.ExternalID)
+	}
+	scope := current.ExternalID[:idx]
+	pos, err := strconv.Atoi(current.ExternalID[idx+1:])
+	if err != nil {
+		return nil, err
+	}
+
+	rule := firewallRuleFromInputs(desired.Inputs)
+	if err := p.api.UpdateFirewallRule(ctx, scope, pos, rule); err != nil {
+		return nil, err
+	}
+
+	return p.readFirewallRule(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+func (p *ProxmoxProvider) deleteFirewallRule(ctx context.Context, state *core.ResourceState) error {
+	idx := strings.LastIndex(state.ExternalID, "/")
+	if idx <= 0 {
+		return fmt.Errorf("proxmox: invalid firewall rule externalID %q", state.ExternalID)
+	}
+	scope := state.ExternalID[:idx]
+	pos, err := strconv.Atoi(state.ExternalID[idx+1:])
+	if err != nil {
+		return err
+	}
+	return p.api.DeleteFirewallRule(ctx, scope, pos)
+}
+
+// ── Snapshot resource handlers ──────────────────────────────────────────────
+
+func (p *ProxmoxProvider) createSnapshot(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	vmid, ok := toInt(args.Inputs["vmid"])
+	if !ok || vmid == 0 {
+		return nil, fmt.Errorf("proxmox: snapshot requires vmid")
+	}
+	snapName := getStringInputFallback(args.Inputs, "name", args.Name)
+	description, _ := args.Inputs["description"].(string)
+	vmstate, _ := args.Inputs["vmstate"].(bool)
+
+	if err := p.api.CreateSnapshot(ctx, vmid, snapName, description, vmstate); err != nil {
+		return nil, fmt.Errorf("proxmox: create snapshot %q on vm %d: %w", snapName, vmid, err)
+	}
+
+	externalID := fmt.Sprintf("%d/%s", vmid, snapName)
+	return &core.ResourceState{
+		ID:         proxmoxResourceID(args),
+		Type:       args.Type,
+		Name:       args.Name,
+		Status:     core.StatusRunning,
+		Inputs:     args.Inputs,
+		Outputs:    core.Outputs{"vmid": vmid, "snapshot": snapName},
+		ExternalID: externalID,
+		ProviderID: "proxmox",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) readSnapshot(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	// externalID format: "<vmid>/<snapname>"
+	idx := strings.Index(externalID, "/")
+	if idx <= 0 {
+		return nil, fmt.Errorf("proxmox: invalid snapshot externalID %q", externalID)
+	}
+	vmid, err := strconv.Atoi(externalID[:idx])
+	if err != nil {
+		return nil, fmt.Errorf("proxmox: invalid snapshot vmid in %q: %w", externalID, err)
+	}
+	snapName := externalID[idx+1:]
+
+	info, err := p.api.ReadSnapshot(ctx, vmid, snapName)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil {
+		return nil, nil
+	}
+
+	inputs := core.Inputs{
+		"vmid":    vmid,
+		"name":    info.Name,
+		"vmstate": info.VMState,
+	}
+	if info.Description != "" {
+		inputs["description"] = info.Description
+	}
+
+	return &core.ResourceState{
+		ID:         id,
+		Type:       "proxmox:snapshot",
+		ExternalID: externalID,
+		ProviderID: "proxmox",
+		Status:     core.StatusRunning,
+		Inputs:     inputs,
+		Outputs:    core.Outputs{"vmid": vmid, "snapshot": snapName},
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) deleteSnapshot(ctx context.Context, state *core.ResourceState) error {
+	idx := strings.Index(state.ExternalID, "/")
+	if idx <= 0 {
+		return fmt.Errorf("proxmox: invalid snapshot externalID %q", state.ExternalID)
+	}
+	vmid, err := strconv.Atoi(state.ExternalID[:idx])
+	if err != nil {
+		return err
+	}
+	snapName := state.ExternalID[idx+1:]
+	return p.api.DeleteSnapshot(ctx, vmid, snapName)
+}
+
+// ── Pool resource handlers ──────────────────────────────────────────────────
+
+func (p *ProxmoxProvider) createPool(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	poolid := getStringInputFallback(args.Inputs, "poolid", args.Name)
+	comment, _ := args.Inputs["comment"].(string)
+
+	if err := p.api.CreatePool(ctx, poolid, comment); err != nil {
+		return nil, fmt.Errorf("proxmox: create pool %q: %w", poolid, err)
+	}
+
+	return &core.ResourceState{
+		ID:         proxmoxResourceID(args),
+		Type:       args.Type,
+		Name:       args.Name,
+		Status:     core.StatusRunning,
+		Inputs:     args.Inputs,
+		Outputs:    core.Outputs{"poolid": poolid},
+		ExternalID: poolid,
+		ProviderID: "proxmox",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) readPool(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadPool(ctx, externalID)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil {
+		return nil, nil
+	}
+
+	inputs := core.Inputs{"poolid": info.PoolID}
+	if info.Comment != "" {
+		inputs["comment"] = info.Comment
+	}
+
+	return &core.ResourceState{
+		ID:         id,
+		Type:       "proxmox:pool",
+		ExternalID: externalID,
+		ProviderID: "proxmox",
+		Status:     core.StatusRunning,
+		Inputs:     inputs,
+		Outputs:    core.Outputs{"poolid": info.PoolID},
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) updatePool(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	comment, _ := desired.Inputs["comment"].(string)
+	if err := p.api.UpdatePool(ctx, current.ExternalID, comment); err != nil {
+		return nil, err
+	}
+	return p.readPool(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+func (p *ProxmoxProvider) deletePool(ctx context.Context, state *core.ResourceState) error {
+	return p.api.DeletePool(ctx, state.ExternalID)
+}
+
+// ── Backup job resource handlers ────────────────────────────────────────────
+
+func backupJobFromInputs(inputs core.Inputs) BackupJobInfo {
+	getString := func(k string) string { v, _ := inputs[k].(string); return v }
+	getBool := func(k string) bool { v, _ := inputs[k].(bool); return v }
+	return BackupJobInfo{
+		VMID:         getString("vmid"),
+		Storage:      getString("storage"),
+		Mode:         getString("mode"),
+		Compress:     getString("compress"),
+		Mailto:       getString("mailto"),
+		Schedule:     getString("schedule"),
+		Enabled:      getBool("enabled"),
+		PruneBackups: getString("prune_backups"),
+	}
+}
+
+func (p *ProxmoxProvider) createBackupJob(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	job := backupJobFromInputs(args.Inputs)
+
+	id, err := p.api.CreateBackupJob(ctx, job)
+	if err != nil {
+		return nil, fmt.Errorf("proxmox: create backup job %q: %w", args.Name, err)
+	}
+
+	return &core.ResourceState{
+		ID:         proxmoxResourceID(args),
+		Type:       args.Type,
+		Name:       args.Name,
+		Status:     core.StatusRunning,
+		Inputs:     args.Inputs,
+		Outputs:    core.Outputs{"job_id": id},
+		ExternalID: id,
+		ProviderID: "proxmox",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) readBackupJob(ctx context.Context, resID core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadBackupJob(ctx, externalID)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil {
+		return nil, nil
+	}
+
+	inputs := core.Inputs{"enabled": info.Enabled}
+	setIfNonEmpty := func(k, v string) { if v != "" { inputs[k] = v } }
+	setIfNonEmpty("vmid", info.VMID)
+	setIfNonEmpty("storage", info.Storage)
+	setIfNonEmpty("mode", info.Mode)
+	setIfNonEmpty("compress", info.Compress)
+	setIfNonEmpty("mailto", info.Mailto)
+	setIfNonEmpty("schedule", info.Schedule)
+	setIfNonEmpty("prune_backups", info.PruneBackups)
+
+	return &core.ResourceState{
+		ID:         resID,
+		Type:       "proxmox:backup",
+		ExternalID: externalID,
+		ProviderID: "proxmox",
+		Status:     core.StatusRunning,
+		Inputs:     inputs,
+		Outputs:    core.Outputs{"job_id": externalID},
+		UpdatedAt:  time.Now(),
+	}, nil
+}
+
+func (p *ProxmoxProvider) updateBackupJob(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	job := backupJobFromInputs(desired.Inputs)
+	if err := p.api.UpdateBackupJob(ctx, current.ExternalID, job); err != nil {
+		return nil, err
+	}
+	return p.readBackupJob(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+func (p *ProxmoxProvider) deleteBackupJob(ctx context.Context, state *core.ResourceState) error {
+	return p.api.DeleteBackupJob(ctx, state.ExternalID)
+}
+
+// ── SDN Zone resource handlers ──────────────────────────────────────────────
+
+func sdnZoneFromInputs(inputs core.Inputs) SDNZoneInfo {
+	gs := func(k string) string { v, _ := inputs[k].(string); return v }
+	gi := func(k string) int { v, _ := toInt(inputs[k]); return v }
+	return SDNZoneInfo{Zone: gs("zone"), Type: gs("type"), Bridge: gs("bridge"), MTU: gi("mtu"), Nodes: gs("nodes"), DNS: gs("dns"), ReverseDNS: gs("reversedns"), DNSZone: gs("dnszone"), IPAM: gs("ipam")}
+}
+
+func sdnZoneToInputs(info *SDNZoneInfo) core.Inputs {
+	inputs := core.Inputs{"zone": info.Zone, "type": info.Type}
+	s := func(k, v string) { if v != "" { inputs[k] = v } }
+	s("bridge", info.Bridge); s("nodes", info.Nodes); s("dns", info.DNS); s("reversedns", info.ReverseDNS); s("dnszone", info.DNSZone); s("ipam", info.IPAM)
+	if info.MTU != 0 { inputs["mtu"] = info.MTU }
+	return inputs
+}
+
+func (p *ProxmoxProvider) createSDNZone(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	info := sdnZoneFromInputs(args.Inputs)
+	if info.Zone == "" { info.Zone = args.Name }
+	if err := p.api.CreateSDNZone(ctx, info); err != nil {
+		return nil, fmt.Errorf("proxmox: create sdn_zone %q: %w", info.Zone, err)
+	}
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"zone": info.Zone}, ExternalID: info.Zone, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readSDNZoneRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadSDNZone(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	return &core.ResourceState{ID: id, Type: "proxmox:sdn_zone", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: sdnZoneToInputs(info), Outputs: core.Outputs{"zone": info.Zone}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateSDNZoneRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	info := sdnZoneFromInputs(desired.Inputs)
+	if err := p.api.UpdateSDNZone(ctx, current.ExternalID, info); err != nil { return nil, err }
+	return p.readSDNZoneRes(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+// ── SDN Vnet resource handlers ──────────────────────────────────────────────
+
+func sdnVnetFromInputs(inputs core.Inputs) SDNVnetInfo {
+	gs := func(k string) string { v, _ := inputs[k].(string); return v }
+	gi := func(k string) int { v, _ := toInt(inputs[k]); return v }
+	gb := func(k string) bool { v, _ := inputs[k].(bool); return v }
+	return SDNVnetInfo{Vnet: gs("vnet"), Zone: gs("zone"), Tag: gi("tag"), Alias: gs("alias"), VlanAware: gb("vlanaware")}
+}
+
+func sdnVnetToInputs(info *SDNVnetInfo) core.Inputs {
+	inputs := core.Inputs{"vnet": info.Vnet, "zone": info.Zone}
+	if info.Tag != 0 { inputs["tag"] = info.Tag }
+	if info.Alias != "" { inputs["alias"] = info.Alias }
+	if info.VlanAware { inputs["vlanaware"] = true }
+	return inputs
+}
+
+func (p *ProxmoxProvider) createSDNVnet(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	info := sdnVnetFromInputs(args.Inputs)
+	if info.Vnet == "" { info.Vnet = args.Name }
+	if err := p.api.CreateSDNVnet(ctx, info); err != nil {
+		return nil, fmt.Errorf("proxmox: create sdn_vnet %q: %w", info.Vnet, err)
+	}
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"vnet": info.Vnet}, ExternalID: info.Vnet, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readSDNVnetRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadSDNVnet(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	return &core.ResourceState{ID: id, Type: "proxmox:sdn_vnet", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: sdnVnetToInputs(info), Outputs: core.Outputs{"vnet": info.Vnet}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateSDNVnetRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	info := sdnVnetFromInputs(desired.Inputs)
+	if err := p.api.UpdateSDNVnet(ctx, current.ExternalID, info); err != nil { return nil, err }
+	return p.readSDNVnetRes(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+// ── SDN Subnet resource handlers ────────────────────────────────────────────
+
+func (p *ProxmoxProvider) createSDNSubnet(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	gs := func(k string) string { v, _ := args.Inputs[k].(string); return v }
+	gb := func(k string) bool { v, _ := args.Inputs[k].(bool); return v }
+	vnet := gs("vnet")
+	info := SDNSubnetInfo{Subnet: gs("subnet"), Vnet: vnet, Gateway: gs("gateway"), SNAT: gb("snat"), DNSZonePrefix: gs("dnszoneprefix")}
+	if err := p.api.CreateSDNSubnet(ctx, vnet, info); err != nil {
+		return nil, fmt.Errorf("proxmox: create sdn_subnet %q: %w", info.Subnet, err)
+	}
+	eid := vnet + "/" + info.Subnet
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"subnet": info.Subnet, "vnet": vnet}, ExternalID: eid, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readSDNSubnetRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	parts := strings.SplitN(externalID, "/", 2)
+	if len(parts) != 2 { return nil, fmt.Errorf("proxmox: invalid sdn_subnet externalID %q", externalID) }
+	info, err := p.api.ReadSDNSubnet(ctx, parts[0], parts[1])
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	inputs := core.Inputs{"subnet": info.Subnet, "vnet": info.Vnet}
+	if info.Gateway != "" { inputs["gateway"] = info.Gateway }
+	if info.SNAT { inputs["snat"] = true }
+	if info.DNSZonePrefix != "" { inputs["dnszoneprefix"] = info.DNSZonePrefix }
+	return &core.ResourceState{ID: id, Type: "proxmox:sdn_subnet", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: inputs, Outputs: core.Outputs{"subnet": info.Subnet, "vnet": info.Vnet}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateSDNSubnetRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	parts := strings.SplitN(current.ExternalID, "/", 2)
+	if len(parts) != 2 { return nil, fmt.Errorf("proxmox: invalid sdn_subnet externalID %q", current.ExternalID) }
+	gs := func(k string) string { v, _ := desired.Inputs[k].(string); return v }
+	gb := func(k string) bool { v, _ := desired.Inputs[k].(bool); return v }
+	info := SDNSubnetInfo{Subnet: gs("subnet"), Vnet: parts[0], Gateway: gs("gateway"), SNAT: gb("snat"), DNSZonePrefix: gs("dnszoneprefix")}
+	if err := p.api.UpdateSDNSubnet(ctx, parts[0], parts[1], info); err != nil { return nil, err }
+	return p.readSDNSubnetRes(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+// ── HA Group resource handlers ──────────────────────────────────────────────
+
+func haGroupFromInputs(inputs core.Inputs) HAGroupInfo {
+	gs := func(k string) string { v, _ := inputs[k].(string); return v }
+	gb := func(k string) bool { v, _ := inputs[k].(bool); return v }
+	return HAGroupInfo{Group: gs("group"), Nodes: gs("nodes"), Restricted: gb("restricted"), NoFailback: gb("nofailback"), Comment: gs("comment")}
+}
+
+func haGroupToInputs(info *HAGroupInfo) core.Inputs {
+	inputs := core.Inputs{"group": info.Group}
+	if info.Nodes != "" { inputs["nodes"] = info.Nodes }
+	if info.Restricted { inputs["restricted"] = true }
+	if info.NoFailback { inputs["nofailback"] = true }
+	if info.Comment != "" { inputs["comment"] = info.Comment }
+	return inputs
+}
+
+func (p *ProxmoxProvider) createHAGroup(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	info := haGroupFromInputs(args.Inputs)
+	if info.Group == "" { info.Group = args.Name }
+	if err := p.api.CreateHAGroup(ctx, info); err != nil { return nil, fmt.Errorf("proxmox: create ha_group %q: %w", info.Group, err) }
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"group": info.Group}, ExternalID: info.Group, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readHAGroupRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadHAGroup(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	return &core.ResourceState{ID: id, Type: "proxmox:ha_group", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: haGroupToInputs(info), Outputs: core.Outputs{"group": info.Group}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateHAGroupRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	info := haGroupFromInputs(desired.Inputs)
+	if err := p.api.UpdateHAGroup(ctx, current.ExternalID, info); err != nil { return nil, err }
+	return p.readHAGroupRes(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+// ── HA Resource handlers ────────────────────────────────────────────────────
+
+func haResourceFromInputs(inputs core.Inputs) HAResourceInfo {
+	gs := func(k string) string { v, _ := inputs[k].(string); return v }
+	gi := func(k string) int { v, _ := toInt(inputs[k]); return v }
+	return HAResourceInfo{SID: gs("sid"), Group: gs("group"), MaxRelocate: gi("max_relocate"), MaxRestart: gi("max_restart"), State: gs("state"), Comment: gs("comment")}
+}
+
+func haResourceToInputs(info *HAResourceInfo) core.Inputs {
+	inputs := core.Inputs{"sid": info.SID}
+	if info.Group != "" { inputs["group"] = info.Group }
+	if info.MaxRelocate != 0 { inputs["max_relocate"] = info.MaxRelocate }
+	if info.MaxRestart != 0 { inputs["max_restart"] = info.MaxRestart }
+	if info.State != "" { inputs["state"] = info.State }
+	if info.Comment != "" { inputs["comment"] = info.Comment }
+	return inputs
+}
+
+func (p *ProxmoxProvider) createHAResource(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	info := haResourceFromInputs(args.Inputs)
+	if err := p.api.CreateHAResource(ctx, info); err != nil { return nil, fmt.Errorf("proxmox: create ha_resource %q: %w", info.SID, err) }
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"sid": info.SID}, ExternalID: info.SID, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readHAResourceRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadHAResource(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	return &core.ResourceState{ID: id, Type: "proxmox:ha_resource", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: haResourceToInputs(info), Outputs: core.Outputs{"sid": info.SID}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateHAResourceRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	info := haResourceFromInputs(desired.Inputs)
+	if err := p.api.UpdateHAResource(ctx, current.ExternalID, info); err != nil { return nil, err }
+	return p.readHAResourceRes(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+// ── ACME Account resource handlers ──────────────────────────────────────────
+
+func (p *ProxmoxProvider) createACMEAccount(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	gs := func(k string) string { v, _ := args.Inputs[k].(string); return v }
+	info := ACMEAccountInfo{Name: getStringInputFallback(args.Inputs, "name", args.Name), Contact: gs("contact"), Directory: gs("directory")}
+	if err := p.api.CreateACMEAccount(ctx, info); err != nil { return nil, fmt.Errorf("proxmox: create acme_account %q: %w", info.Name, err) }
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"name": info.Name}, ExternalID: info.Name, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readACMEAccountRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadACMEAccount(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	inputs := core.Inputs{"name": info.Name}
+	if info.Contact != "" { inputs["contact"] = info.Contact }
+	if info.Directory != "" { inputs["directory"] = info.Directory }
+	return &core.ResourceState{ID: id, Type: "proxmox:acme_account", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: inputs, Outputs: core.Outputs{"name": info.Name}, UpdatedAt: time.Now()}, nil
+}
+
+// ── User resource handlers ──────────────────────────────────────────────────
+
+func pveUserFromInputs(inputs core.Inputs) PVEUserInfo {
+	gs := func(k string) string { v, _ := inputs[k].(string); return v }
+	gb := func(k string) bool { v, _ := inputs[k].(bool); return v }
+	gi := func(k string) int { v, _ := toInt(inputs[k]); return v }
+	return PVEUserInfo{UserID: gs("userid"), Email: gs("email"), FirstName: gs("firstname"), LastName: gs("lastname"), Groups: gs("groups"), Enable: gb("enable"), Expire: gi("expire"), Comment: gs("comment")}
+}
+
+func pveUserToInputs(info *PVEUserInfo) core.Inputs {
+	inputs := core.Inputs{"userid": info.UserID, "enable": info.Enable}
+	s := func(k, v string) { if v != "" { inputs[k] = v } }
+	s("email", info.Email); s("firstname", info.FirstName); s("lastname", info.LastName); s("groups", info.Groups); s("comment", info.Comment)
+	if info.Expire != 0 { inputs["expire"] = info.Expire }
+	return inputs
+}
+
+func (p *ProxmoxProvider) createUser(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	info := pveUserFromInputs(args.Inputs)
+	if err := p.api.CreateUser(ctx, info); err != nil { return nil, fmt.Errorf("proxmox: create user %q: %w", info.UserID, err) }
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"userid": info.UserID}, ExternalID: info.UserID, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readUserRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadUser(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	return &core.ResourceState{ID: id, Type: "proxmox:user", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: pveUserToInputs(info), Outputs: core.Outputs{"userid": info.UserID}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateUserRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	info := pveUserFromInputs(desired.Inputs)
+	if err := p.api.UpdateUser(ctx, current.ExternalID, info); err != nil { return nil, err }
+	return p.readUserRes(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+// ── Role resource handlers ──────────────────────────────────────────────────
+
+func (p *ProxmoxProvider) createRole(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	gs := func(k string) string { v, _ := args.Inputs[k].(string); return v }
+	info := PVERoleInfo{RoleID: getStringInputFallback(args.Inputs, "roleid", args.Name), Privs: gs("privs")}
+	if err := p.api.CreateRole(ctx, info); err != nil { return nil, fmt.Errorf("proxmox: create role %q: %w", info.RoleID, err) }
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"roleid": info.RoleID}, ExternalID: info.RoleID, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readRoleRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadRole(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	inputs := core.Inputs{"roleid": info.RoleID}
+	if info.Privs != "" { inputs["privs"] = info.Privs }
+	return &core.ResourceState{ID: id, Type: "proxmox:role", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: inputs, Outputs: core.Outputs{"roleid": info.RoleID}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateRoleRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	gs := func(k string) string { v, _ := desired.Inputs[k].(string); return v }
+	info := PVERoleInfo{RoleID: current.ExternalID, Privs: gs("privs")}
+	if err := p.api.UpdateRole(ctx, current.ExternalID, info); err != nil { return nil, err }
+	return p.readRoleRes(ctx, proxmoxResourceID(desired), current.ExternalID)
+}
+
+// ── ACL resource handlers ───────────────────────────────────────────────────
+
+func (p *ProxmoxProvider) createACL(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	gs := func(k string) string { v, _ := args.Inputs[k].(string); return v }
+	gb := func(k string) bool { v, _ := args.Inputs[k].(bool); return v }
+	info := PVEACLInfo{Path: gs("path"), Roles: gs("roles"), Users: gs("users"), Groups: gs("groups"), Propagate: gb("propagate")}
+	if err := p.api.SetACL(ctx, info); err != nil { return nil, fmt.Errorf("proxmox: set acl on %q: %w", info.Path, err) }
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{"path": info.Path}, ExternalID: info.Path, ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readACLRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadACL(ctx, externalID)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	inputs := core.Inputs{"path": info.Path}
+	if info.Roles != "" { inputs["roles"] = info.Roles }
+	if info.Users != "" { inputs["users"] = info.Users }
+	if info.Groups != "" { inputs["groups"] = info.Groups }
+	if info.Propagate { inputs["propagate"] = true }
+	return &core.ResourceState{ID: id, Type: "proxmox:acl", ExternalID: externalID, ProviderID: "proxmox", Status: core.StatusRunning, Inputs: inputs, Outputs: core.Outputs{"path": info.Path}, UpdatedAt: time.Now()}, nil
+}
+
+// ── Cluster Options resource handlers ───────────────────────────────────────
+
+func clusterOptsFromInputs(inputs core.Inputs) ClusterOptionsInfo {
+	gs := func(k string) string { v, _ := inputs[k].(string); return v }
+	return ClusterOptionsInfo{Keyboard: gs("keyboard"), Language: gs("language"), EmailFrom: gs("email_from"), MigrationType: gs("migration_type"), MigrationNetwork: gs("migration_network")}
+}
+
+func clusterOptsToInputs(info *ClusterOptionsInfo) core.Inputs {
+	inputs := core.Inputs{}
+	s := func(k, v string) { if v != "" { inputs[k] = v } }
+	s("keyboard", info.Keyboard); s("language", info.Language); s("email_from", info.EmailFrom); s("migration_type", info.MigrationType); s("migration_network", info.MigrationNetwork)
+	return inputs
+}
+
+func (p *ProxmoxProvider) createClusterOptions(ctx context.Context, args core.ResourceArgs) (*core.ResourceState, error) {
+	opts := clusterOptsFromInputs(args.Inputs)
+	if err := p.api.UpdateClusterOptions(ctx, opts); err != nil { return nil, fmt.Errorf("proxmox: set cluster options: %w", err) }
+	return &core.ResourceState{ID: proxmoxResourceID(args), Type: args.Type, Name: args.Name, Status: core.StatusRunning, Inputs: args.Inputs, Outputs: core.Outputs{}, ExternalID: "cluster", ProviderID: "proxmox", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) readClusterOptionsRes(ctx context.Context, id core.ResourceID, externalID string) (*core.ResourceState, error) {
+	info, err := p.api.ReadClusterOptions(ctx)
+	if err != nil { return nil, err }
+	if info == nil { return nil, nil }
+	return &core.ResourceState{ID: id, Type: "proxmox:cluster_options", ExternalID: "cluster", ProviderID: "proxmox", Status: core.StatusRunning, Inputs: clusterOptsToInputs(info), Outputs: core.Outputs{}, UpdatedAt: time.Now()}, nil
+}
+
+func (p *ProxmoxProvider) updateClusterOptionsRes(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
+	opts := clusterOptsFromInputs(desired.Inputs)
+	if err := p.api.UpdateClusterOptions(ctx, opts); err != nil { return nil, err }
+	return p.readClusterOptionsRes(ctx, proxmoxResourceID(desired), "cluster")
 }

--- a/providers/foss/proxmox_api_real.go
+++ b/providers/foss/proxmox_api_real.go
@@ -457,3 +457,194 @@ func applyNetworkConfig(nw *proxmox.NodeNetwork, cfg NetworkConfig) {
 		nw.Autostart = 0
 	}
 }
+
+// ── Firewall rules (stub) ───────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateFirewallRule(_ context.Context, _ string, _ FirewallRuleInfo) (int, error) {
+	return 0, fmt.Errorf("proxmox: CreateFirewallRule not yet implemented")
+}
+
+func (r *realProxmoxAPI) ReadFirewallRule(_ context.Context, _ string, _ int) (*FirewallRuleInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadFirewallRule not yet implemented")
+}
+
+func (r *realProxmoxAPI) UpdateFirewallRule(_ context.Context, _ string, _ int, _ FirewallRuleInfo) error {
+	return fmt.Errorf("proxmox: UpdateFirewallRule not yet implemented")
+}
+
+func (r *realProxmoxAPI) DeleteFirewallRule(_ context.Context, _ string, _ int) error {
+	return fmt.Errorf("proxmox: DeleteFirewallRule not yet implemented")
+}
+
+// ── Snapshots (stub) ────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateSnapshot(_ context.Context, _ int, _, _ string, _ bool) error {
+	return fmt.Errorf("proxmox: CreateSnapshot not yet implemented")
+}
+
+func (r *realProxmoxAPI) ReadSnapshot(_ context.Context, _ int, _ string) (*SnapshotInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadSnapshot not yet implemented")
+}
+
+func (r *realProxmoxAPI) DeleteSnapshot(_ context.Context, _ int, _ string) error {
+	return fmt.Errorf("proxmox: DeleteSnapshot not yet implemented")
+}
+
+// ── Pools (stub) ────────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreatePool(_ context.Context, _, _ string) error {
+	return fmt.Errorf("proxmox: CreatePool not yet implemented")
+}
+
+func (r *realProxmoxAPI) ReadPool(_ context.Context, _ string) (*PoolInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadPool not yet implemented")
+}
+
+func (r *realProxmoxAPI) UpdatePool(_ context.Context, _, _ string) error {
+	return fmt.Errorf("proxmox: UpdatePool not yet implemented")
+}
+
+func (r *realProxmoxAPI) DeletePool(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeletePool not yet implemented")
+}
+
+// ── Backup jobs (stub) ──────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateBackupJob(_ context.Context, _ BackupJobInfo) (string, error) {
+	return "", fmt.Errorf("proxmox: CreateBackupJob not yet implemented")
+}
+
+func (r *realProxmoxAPI) ReadBackupJob(_ context.Context, _ string) (*BackupJobInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadBackupJob not yet implemented")
+}
+
+func (r *realProxmoxAPI) UpdateBackupJob(_ context.Context, _ string, _ BackupJobInfo) error {
+	return fmt.Errorf("proxmox: UpdateBackupJob not yet implemented")
+}
+
+func (r *realProxmoxAPI) DeleteBackupJob(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteBackupJob not yet implemented")
+}
+
+// ── SDN (stub) ──────────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateSDNZone(_ context.Context, _ SDNZoneInfo) error {
+	return fmt.Errorf("proxmox: CreateSDNZone not yet implemented")
+}
+func (r *realProxmoxAPI) ReadSDNZone(_ context.Context, _ string) (*SDNZoneInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadSDNZone not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateSDNZone(_ context.Context, _ string, _ SDNZoneInfo) error {
+	return fmt.Errorf("proxmox: UpdateSDNZone not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteSDNZone(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteSDNZone not yet implemented")
+}
+func (r *realProxmoxAPI) CreateSDNVnet(_ context.Context, _ SDNVnetInfo) error {
+	return fmt.Errorf("proxmox: CreateSDNVnet not yet implemented")
+}
+func (r *realProxmoxAPI) ReadSDNVnet(_ context.Context, _ string) (*SDNVnetInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadSDNVnet not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateSDNVnet(_ context.Context, _ string, _ SDNVnetInfo) error {
+	return fmt.Errorf("proxmox: UpdateSDNVnet not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteSDNVnet(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteSDNVnet not yet implemented")
+}
+func (r *realProxmoxAPI) CreateSDNSubnet(_ context.Context, _ string, _ SDNSubnetInfo) error {
+	return fmt.Errorf("proxmox: CreateSDNSubnet not yet implemented")
+}
+func (r *realProxmoxAPI) ReadSDNSubnet(_ context.Context, _, _ string) (*SDNSubnetInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadSDNSubnet not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateSDNSubnet(_ context.Context, _, _ string, _ SDNSubnetInfo) error {
+	return fmt.Errorf("proxmox: UpdateSDNSubnet not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteSDNSubnet(_ context.Context, _, _ string) error {
+	return fmt.Errorf("proxmox: DeleteSDNSubnet not yet implemented")
+}
+
+// ── HA (stub) ───────────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateHAGroup(_ context.Context, _ HAGroupInfo) error {
+	return fmt.Errorf("proxmox: CreateHAGroup not yet implemented")
+}
+func (r *realProxmoxAPI) ReadHAGroup(_ context.Context, _ string) (*HAGroupInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadHAGroup not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateHAGroup(_ context.Context, _ string, _ HAGroupInfo) error {
+	return fmt.Errorf("proxmox: UpdateHAGroup not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteHAGroup(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteHAGroup not yet implemented")
+}
+func (r *realProxmoxAPI) CreateHAResource(_ context.Context, _ HAResourceInfo) error {
+	return fmt.Errorf("proxmox: CreateHAResource not yet implemented")
+}
+func (r *realProxmoxAPI) ReadHAResource(_ context.Context, _ string) (*HAResourceInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadHAResource not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateHAResource(_ context.Context, _ string, _ HAResourceInfo) error {
+	return fmt.Errorf("proxmox: UpdateHAResource not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteHAResource(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteHAResource not yet implemented")
+}
+
+// ── ACME (stub) ─────────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateACMEAccount(_ context.Context, _ ACMEAccountInfo) error {
+	return fmt.Errorf("proxmox: CreateACMEAccount not yet implemented")
+}
+func (r *realProxmoxAPI) ReadACMEAccount(_ context.Context, _ string) (*ACMEAccountInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadACMEAccount not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteACMEAccount(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteACMEAccount not yet implemented")
+}
+
+// ── Users/Roles/ACLs (stub) ─────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateUser(_ context.Context, _ PVEUserInfo) error {
+	return fmt.Errorf("proxmox: CreateUser not yet implemented")
+}
+func (r *realProxmoxAPI) ReadUser(_ context.Context, _ string) (*PVEUserInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadUser not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateUser(_ context.Context, _ string, _ PVEUserInfo) error {
+	return fmt.Errorf("proxmox: UpdateUser not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteUser(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteUser not yet implemented")
+}
+func (r *realProxmoxAPI) CreateRole(_ context.Context, _ PVERoleInfo) error {
+	return fmt.Errorf("proxmox: CreateRole not yet implemented")
+}
+func (r *realProxmoxAPI) ReadRole(_ context.Context, _ string) (*PVERoleInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadRole not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateRole(_ context.Context, _ string, _ PVERoleInfo) error {
+	return fmt.Errorf("proxmox: UpdateRole not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteRole(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteRole not yet implemented")
+}
+func (r *realProxmoxAPI) SetACL(_ context.Context, _ PVEACLInfo) error {
+	return fmt.Errorf("proxmox: SetACL not yet implemented")
+}
+func (r *realProxmoxAPI) ReadACL(_ context.Context, _ string) (*PVEACLInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadACL not yet implemented")
+}
+func (r *realProxmoxAPI) DeleteACL(_ context.Context, _ string) error {
+	return fmt.Errorf("proxmox: DeleteACL not yet implemented")
+}
+
+// ── Cluster options (stub) ──────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) ReadClusterOptions(_ context.Context) (*ClusterOptionsInfo, error) {
+	return nil, fmt.Errorf("proxmox: ReadClusterOptions not yet implemented")
+}
+func (r *realProxmoxAPI) UpdateClusterOptions(_ context.Context, _ ClusterOptionsInfo) error {
+	return fmt.Errorf("proxmox: UpdateClusterOptions not yet implemented")
+}

--- a/providers/foss/proxmox_test.go
+++ b/providers/foss/proxmox_test.go
@@ -38,6 +38,62 @@ type mockProxmoxAPI struct {
 	updateNetwork func(ctx context.Context, iface string, cfg NetworkConfig) error
 	deleteNetwork func(ctx context.Context, iface string) error
 	reloadNetwork func(ctx context.Context) error
+
+	createFirewallRule func(ctx context.Context, scope string, rule FirewallRuleInfo) (int, error)
+	readFirewallRule   func(ctx context.Context, scope string, pos int) (*FirewallRuleInfo, error)
+	updateFirewallRule func(ctx context.Context, scope string, pos int, rule FirewallRuleInfo) error
+	deleteFirewallRule func(ctx context.Context, scope string, pos int) error
+
+	createSnapshot func(ctx context.Context, vmid int, name, description string, vmstate bool) error
+	readSnapshot   func(ctx context.Context, vmid int, name string) (*SnapshotInfo, error)
+	deleteSnapshot func(ctx context.Context, vmid int, name string) error
+
+	createPool func(ctx context.Context, poolid, comment string) error
+	readPool   func(ctx context.Context, poolid string) (*PoolInfo, error)
+	updatePool func(ctx context.Context, poolid, comment string) error
+	deletePool func(ctx context.Context, poolid string) error
+
+	createBackupJob func(ctx context.Context, job BackupJobInfo) (string, error)
+	readBackupJob   func(ctx context.Context, id string) (*BackupJobInfo, error)
+	updateBackupJob func(ctx context.Context, id string, job BackupJobInfo) error
+	deleteBackupJob func(ctx context.Context, id string) error
+
+	createSDNZone func(ctx context.Context, zone SDNZoneInfo) error
+	readSDNZone   func(ctx context.Context, zone string) (*SDNZoneInfo, error)
+	updateSDNZone func(ctx context.Context, zone string, info SDNZoneInfo) error
+	deleteSDNZone func(ctx context.Context, zone string) error
+	createSDNVnet func(ctx context.Context, vnet SDNVnetInfo) error
+	readSDNVnet   func(ctx context.Context, vnet string) (*SDNVnetInfo, error)
+	updateSDNVnet func(ctx context.Context, vnet string, info SDNVnetInfo) error
+	deleteSDNVnet func(ctx context.Context, vnet string) error
+	createSDNSubnet func(ctx context.Context, vnet string, subnet SDNSubnetInfo) error
+	readSDNSubnet   func(ctx context.Context, vnet, subnet string) (*SDNSubnetInfo, error)
+	updateSDNSubnet func(ctx context.Context, vnet, subnet string, info SDNSubnetInfo) error
+	deleteSDNSubnet func(ctx context.Context, vnet, subnet string) error
+	createHAGroup func(ctx context.Context, group HAGroupInfo) error
+	readHAGroup   func(ctx context.Context, group string) (*HAGroupInfo, error)
+	updateHAGroup func(ctx context.Context, group string, info HAGroupInfo) error
+	deleteHAGroup func(ctx context.Context, group string) error
+	createHAResource func(ctx context.Context, res HAResourceInfo) error
+	readHAResource   func(ctx context.Context, sid string) (*HAResourceInfo, error)
+	updateHAResource func(ctx context.Context, sid string, info HAResourceInfo) error
+	deleteHAResource func(ctx context.Context, sid string) error
+	createACMEAccount func(ctx context.Context, acct ACMEAccountInfo) error
+	readACMEAccount   func(ctx context.Context, name string) (*ACMEAccountInfo, error)
+	deleteACMEAccount func(ctx context.Context, name string) error
+	createUser func(ctx context.Context, user PVEUserInfo) error
+	readUser   func(ctx context.Context, userid string) (*PVEUserInfo, error)
+	updateUser func(ctx context.Context, userid string, user PVEUserInfo) error
+	deleteUser func(ctx context.Context, userid string) error
+	createRole func(ctx context.Context, role PVERoleInfo) error
+	readRole   func(ctx context.Context, roleid string) (*PVERoleInfo, error)
+	updateRole func(ctx context.Context, roleid string, role PVERoleInfo) error
+	deleteRole func(ctx context.Context, roleid string) error
+	setACL     func(ctx context.Context, acl PVEACLInfo) error
+	readACL    func(ctx context.Context, path string) (*PVEACLInfo, error)
+	deleteACL  func(ctx context.Context, path string) error
+	readClusterOptions   func(ctx context.Context) (*ClusterOptionsInfo, error)
+	updateClusterOptions func(ctx context.Context, opts ClusterOptionsInfo) error
 }
 
 func (m *mockProxmoxAPI) NextVMID(ctx context.Context) (int, error) {
@@ -96,6 +152,98 @@ func (m *mockProxmoxAPI) DeleteNetwork(ctx context.Context, iface string) error 
 	return m.deleteNetwork(ctx, iface)
 }
 func (m *mockProxmoxAPI) ReloadNetwork(ctx context.Context) error { return m.reloadNetwork(ctx) }
+
+func (m *mockProxmoxAPI) CreateFirewallRule(ctx context.Context, scope string, rule FirewallRuleInfo) (int, error) {
+	return m.createFirewallRule(ctx, scope, rule)
+}
+func (m *mockProxmoxAPI) ReadFirewallRule(ctx context.Context, scope string, pos int) (*FirewallRuleInfo, error) {
+	return m.readFirewallRule(ctx, scope, pos)
+}
+func (m *mockProxmoxAPI) UpdateFirewallRule(ctx context.Context, scope string, pos int, rule FirewallRuleInfo) error {
+	return m.updateFirewallRule(ctx, scope, pos, rule)
+}
+func (m *mockProxmoxAPI) DeleteFirewallRule(ctx context.Context, scope string, pos int) error {
+	return m.deleteFirewallRule(ctx, scope, pos)
+}
+func (m *mockProxmoxAPI) CreateSnapshot(ctx context.Context, vmid int, name, description string, vmstate bool) error {
+	return m.createSnapshot(ctx, vmid, name, description, vmstate)
+}
+func (m *mockProxmoxAPI) ReadSnapshot(ctx context.Context, vmid int, name string) (*SnapshotInfo, error) {
+	return m.readSnapshot(ctx, vmid, name)
+}
+func (m *mockProxmoxAPI) DeleteSnapshot(ctx context.Context, vmid int, name string) error {
+	return m.deleteSnapshot(ctx, vmid, name)
+}
+func (m *mockProxmoxAPI) CreatePool(ctx context.Context, poolid, comment string) error {
+	return m.createPool(ctx, poolid, comment)
+}
+func (m *mockProxmoxAPI) ReadPool(ctx context.Context, poolid string) (*PoolInfo, error) {
+	return m.readPool(ctx, poolid)
+}
+func (m *mockProxmoxAPI) UpdatePool(ctx context.Context, poolid, comment string) error {
+	return m.updatePool(ctx, poolid, comment)
+}
+func (m *mockProxmoxAPI) DeletePool(ctx context.Context, poolid string) error {
+	return m.deletePool(ctx, poolid)
+}
+func (m *mockProxmoxAPI) CreateBackupJob(ctx context.Context, job BackupJobInfo) (string, error) {
+	return m.createBackupJob(ctx, job)
+}
+func (m *mockProxmoxAPI) ReadBackupJob(ctx context.Context, id string) (*BackupJobInfo, error) {
+	return m.readBackupJob(ctx, id)
+}
+func (m *mockProxmoxAPI) UpdateBackupJob(ctx context.Context, id string, job BackupJobInfo) error {
+	return m.updateBackupJob(ctx, id, job)
+}
+func (m *mockProxmoxAPI) DeleteBackupJob(ctx context.Context, id string) error {
+	return m.deleteBackupJob(ctx, id)
+}
+
+// SDN
+func (m *mockProxmoxAPI) CreateSDNZone(ctx context.Context, z SDNZoneInfo) error { return m.createSDNZone(ctx, z) }
+func (m *mockProxmoxAPI) ReadSDNZone(ctx context.Context, z string) (*SDNZoneInfo, error) { return m.readSDNZone(ctx, z) }
+func (m *mockProxmoxAPI) UpdateSDNZone(ctx context.Context, z string, i SDNZoneInfo) error { return m.updateSDNZone(ctx, z, i) }
+func (m *mockProxmoxAPI) DeleteSDNZone(ctx context.Context, z string) error { return m.deleteSDNZone(ctx, z) }
+func (m *mockProxmoxAPI) CreateSDNVnet(ctx context.Context, v SDNVnetInfo) error { return m.createSDNVnet(ctx, v) }
+func (m *mockProxmoxAPI) ReadSDNVnet(ctx context.Context, v string) (*SDNVnetInfo, error) { return m.readSDNVnet(ctx, v) }
+func (m *mockProxmoxAPI) UpdateSDNVnet(ctx context.Context, v string, i SDNVnetInfo) error { return m.updateSDNVnet(ctx, v, i) }
+func (m *mockProxmoxAPI) DeleteSDNVnet(ctx context.Context, v string) error { return m.deleteSDNVnet(ctx, v) }
+func (m *mockProxmoxAPI) CreateSDNSubnet(ctx context.Context, v string, s SDNSubnetInfo) error { return m.createSDNSubnet(ctx, v, s) }
+func (m *mockProxmoxAPI) ReadSDNSubnet(ctx context.Context, v, s string) (*SDNSubnetInfo, error) { return m.readSDNSubnet(ctx, v, s) }
+func (m *mockProxmoxAPI) UpdateSDNSubnet(ctx context.Context, v, s string, i SDNSubnetInfo) error { return m.updateSDNSubnet(ctx, v, s, i) }
+func (m *mockProxmoxAPI) DeleteSDNSubnet(ctx context.Context, v, s string) error { return m.deleteSDNSubnet(ctx, v, s) }
+
+// HA
+func (m *mockProxmoxAPI) CreateHAGroup(ctx context.Context, g HAGroupInfo) error { return m.createHAGroup(ctx, g) }
+func (m *mockProxmoxAPI) ReadHAGroup(ctx context.Context, g string) (*HAGroupInfo, error) { return m.readHAGroup(ctx, g) }
+func (m *mockProxmoxAPI) UpdateHAGroup(ctx context.Context, g string, i HAGroupInfo) error { return m.updateHAGroup(ctx, g, i) }
+func (m *mockProxmoxAPI) DeleteHAGroup(ctx context.Context, g string) error { return m.deleteHAGroup(ctx, g) }
+func (m *mockProxmoxAPI) CreateHAResource(ctx context.Context, r HAResourceInfo) error { return m.createHAResource(ctx, r) }
+func (m *mockProxmoxAPI) ReadHAResource(ctx context.Context, s string) (*HAResourceInfo, error) { return m.readHAResource(ctx, s) }
+func (m *mockProxmoxAPI) UpdateHAResource(ctx context.Context, s string, i HAResourceInfo) error { return m.updateHAResource(ctx, s, i) }
+func (m *mockProxmoxAPI) DeleteHAResource(ctx context.Context, s string) error { return m.deleteHAResource(ctx, s) }
+
+// ACME
+func (m *mockProxmoxAPI) CreateACMEAccount(ctx context.Context, a ACMEAccountInfo) error { return m.createACMEAccount(ctx, a) }
+func (m *mockProxmoxAPI) ReadACMEAccount(ctx context.Context, n string) (*ACMEAccountInfo, error) { return m.readACMEAccount(ctx, n) }
+func (m *mockProxmoxAPI) DeleteACMEAccount(ctx context.Context, n string) error { return m.deleteACMEAccount(ctx, n) }
+
+// Users/Roles/ACLs
+func (m *mockProxmoxAPI) CreateUser(ctx context.Context, u PVEUserInfo) error { return m.createUser(ctx, u) }
+func (m *mockProxmoxAPI) ReadUser(ctx context.Context, u string) (*PVEUserInfo, error) { return m.readUser(ctx, u) }
+func (m *mockProxmoxAPI) UpdateUser(ctx context.Context, u string, i PVEUserInfo) error { return m.updateUser(ctx, u, i) }
+func (m *mockProxmoxAPI) DeleteUser(ctx context.Context, u string) error { return m.deleteUser(ctx, u) }
+func (m *mockProxmoxAPI) CreateRole(ctx context.Context, r PVERoleInfo) error { return m.createRole(ctx, r) }
+func (m *mockProxmoxAPI) ReadRole(ctx context.Context, r string) (*PVERoleInfo, error) { return m.readRole(ctx, r) }
+func (m *mockProxmoxAPI) UpdateRole(ctx context.Context, r string, i PVERoleInfo) error { return m.updateRole(ctx, r, i) }
+func (m *mockProxmoxAPI) DeleteRole(ctx context.Context, r string) error { return m.deleteRole(ctx, r) }
+func (m *mockProxmoxAPI) SetACL(ctx context.Context, a PVEACLInfo) error { return m.setACL(ctx, a) }
+func (m *mockProxmoxAPI) ReadACL(ctx context.Context, p string) (*PVEACLInfo, error) { return m.readACL(ctx, p) }
+func (m *mockProxmoxAPI) DeleteACL(ctx context.Context, p string) error { return m.deleteACL(ctx, p) }
+
+// Cluster
+func (m *mockProxmoxAPI) ReadClusterOptions(ctx context.Context) (*ClusterOptionsInfo, error) { return m.readClusterOptions(ctx) }
+func (m *mockProxmoxAPI) UpdateClusterOptions(ctx context.Context, o ClusterOptionsInfo) error { return m.updateClusterOptions(ctx, o) }
 
 // newTestProvider returns a ProxmoxProvider with the given mock injected.
 func newTestProvider(mock *mockProxmoxAPI) *ProxmoxProvider {


### PR DESCRIPTION
## Proxmox full resource coverage + Gitea mirror workflow

### Summary

Expands the Proxmox provider from 4 resource types with minimal fields to **18 resource types** with full configuration coverage. Also adds a GitHub Actions workflow to automatically mirror all branches and tags to Gitea.

### Proxmox provider

**P0 — Enriched existing resources:**
- `proxmox:vm` — 5 → 34 fields (cloud-init, multi-disk, multi-NIC, CPU model, firmware, display, metadata)
- `proxmox:lxc` — 5 → 23 fields (swap, mount points, unprivileged, features, DNS, multi-NIC)
- `proxmox:storage` — 3 → 10 fields (Ceph/ZFS pool, shared, prune backups)
- `proxmox:network` — 5 → 14 fields (VLAN, MTU, bonding, IPv6)

**P1 — New resource types:**
- `proxmox:firewall_rule` — node/VM/cluster-level rules with full proto/port/source/dest support
- `proxmox:snapshot` — VM/CT snapshots with RAM state option
- `proxmox:pool` — Resource pools with member management
- `proxmox:backup` — Backup jobs with scheduling and retention

**P2 — Advanced resource types:**
- `proxmox:sdn_zone`, `proxmox:sdn_vnet`, `proxmox:sdn_subnet` — Software-defined networking
- `proxmox:ha_group`, `proxmox:ha_resource` — High availability
- `proxmox:acme_account` — Let's Encrypt certificate management
- `proxmox:user`, `proxmox:role`, `proxmox:acl` — Access control
- `proxmox:cluster_options` — Cluster-wide settings

### Gitea mirror

Added `.github/workflows/mirror-gitea.yml`:
- Triggers on all pushes and branch deletions
- Fetches Gitea state and logs a diff (commits ahead/behind) before pushing
- Warns if Gitea has commits not on GitHub that will be overwritten
- Requires `GITEA_USERNAME` and `GITEA_TOKEN` secrets

### Closes

- #18 — Enrich proxmox:vm
- #19 — Enrich proxmox:lxc
- #20 — Enrich proxmox:storage
- #21 — Enrich proxmox:network
- #22 — Add proxmox:firewall_rule
- #23 — Add proxmox:snapshot
- #24 — Add proxmox:pool
- #25 — Add proxmox:backup
- #26 — Add Proxmox advanced resources

### Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./providers/foss/` passes
- [x] Add `GITEA_USERNAME` and `GITEA_TOKEN` secrets to repo
- [ ] Verify mirror workflow runs on merge
