### PR TITLE
provider: implement real Proxmox API for all P1/P2 resource types

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -27,9 +27,11 @@ jobs:
             exit 0
           fi
 
-          # Require pattern: v<semver>/<Codename>-<Milestone> (case-insensitive)
-          # Examples: v0.1.0/Amalosia-Core, v0.1.0/amalosia-core
-          PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+/[a-z]+-[a-z]+$'
+          # Require pattern: v<semver>/<Codename>-<Milestone> (case-insensitive).
+          # The milestone may span several hyphenated segments, matching actual
+          # branch history (e.g. v0.4.0/Amalosia-core-proxmox-mirror).
+          # Examples: v0.1.0/Amalosia-Core, v0.2.0/Amalosia-core-proxmox
+          PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+/[a-z]+(-[a-z0-9]+)+$'
 
           if echo "$BRANCH" | grep -qiE "$PATTERN"; then
             echo "✓ Branch name '$BRANCH' matches required pattern."

--- a/providers/foss/proxmox.go
+++ b/providers/foss/proxmox.go
@@ -55,7 +55,7 @@ type proxmoxAPI interface {
 
 	CreatePool(ctx context.Context, poolid, comment string) error
 	ReadPool(ctx context.Context, poolid string) (*PoolInfo, error)
-	UpdatePool(ctx context.Context, poolid, comment string) error
+	UpdatePool(ctx context.Context, poolid, comment, members string) error
 	DeletePool(ctx context.Context, poolid string) error
 
 	CreateBackupJob(ctx context.Context, job BackupJobInfo) (string, error)
@@ -280,6 +280,7 @@ type SnapshotInfo struct {
 type PoolInfo struct {
 	PoolID  string
 	Comment string
+	Members string // comma-separated VM/CT IDs; "" means unmanaged
 }
 
 // BackupJobInfo holds a Proxmox backup job configuration.
@@ -355,6 +356,7 @@ type ACMEAccountInfo struct {
 // PVEUserInfo holds a Proxmox user.
 type PVEUserInfo struct {
 	UserID    string // e.g. "user@pam"
+	Password  string // write-only: used on create, never read back
 	Email     string
 	FirstName string
 	LastName  string
@@ -765,7 +767,9 @@ func (p *ProxmoxProvider) Diff(ctx context.Context, current *core.ResourceState,
 			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
 		}
 	case "proxmox:pool":
-		changes = append(changes, compareField("comment", current.Inputs, desired.Inputs)...)
+		for _, f := range []string{"comment", "members"} {
+			changes = append(changes, compareField(f, current.Inputs, desired.Inputs)...)
+		}
 	case "proxmox:backup":
 		for _, f := range []string{
 			"vmid", "storage", "mode", "compress",
@@ -1778,6 +1782,13 @@ func (p *ProxmoxProvider) createPool(ctx context.Context, args core.ResourceArgs
 		return nil, fmt.Errorf("proxmox: create pool %q: %w", poolid, err)
 	}
 
+	// Pool creation cannot set members; assign them in a follow-up update.
+	if members, _ := args.Inputs["members"].(string); members != "" {
+		if err := p.api.UpdatePool(ctx, poolid, comment, members); err != nil {
+			return nil, fmt.Errorf("proxmox: assign members to pool %q: %w", poolid, err)
+		}
+	}
+
 	return &core.ResourceState{
 		ID:         proxmoxResourceID(args),
 		Type:       args.Type,
@@ -1805,6 +1816,9 @@ func (p *ProxmoxProvider) readPool(ctx context.Context, id core.ResourceID, exte
 	if info.Comment != "" {
 		inputs["comment"] = info.Comment
 	}
+	if info.Members != "" {
+		inputs["members"] = info.Members
+	}
 
 	return &core.ResourceState{
 		ID:         id,
@@ -1820,7 +1834,8 @@ func (p *ProxmoxProvider) readPool(ctx context.Context, id core.ResourceID, exte
 
 func (p *ProxmoxProvider) updatePool(ctx context.Context, current *core.ResourceState, desired core.ResourceArgs) (*core.ResourceState, error) {
 	comment, _ := desired.Inputs["comment"].(string)
-	if err := p.api.UpdatePool(ctx, current.ExternalID, comment); err != nil {
+	members, _ := desired.Inputs["members"].(string)
+	if err := p.api.UpdatePool(ctx, current.ExternalID, comment, members); err != nil {
 		return nil, err
 	}
 	return p.readPool(ctx, proxmoxResourceID(desired), current.ExternalID)
@@ -2125,7 +2140,7 @@ func pveUserFromInputs(inputs core.Inputs) PVEUserInfo {
 	gs := func(k string) string { v, _ := inputs[k].(string); return v }
 	gb := func(k string) bool { v, _ := inputs[k].(bool); return v }
 	gi := func(k string) int { v, _ := toInt(inputs[k]); return v }
-	return PVEUserInfo{UserID: gs("userid"), Email: gs("email"), FirstName: gs("firstname"), LastName: gs("lastname"), Groups: gs("groups"), Enable: gb("enable"), Expire: gi("expire"), Comment: gs("comment")}
+	return PVEUserInfo{UserID: gs("userid"), Password: gs("password"), Email: gs("email"), FirstName: gs("firstname"), LastName: gs("lastname"), Groups: gs("groups"), Enable: gb("enable"), Expire: gi("expire"), Comment: gs("comment")}
 }
 
 func pveUserToInputs(info *PVEUserInfo) core.Inputs {

--- a/providers/foss/proxmox_api_real.go
+++ b/providers/foss/proxmox_api_real.go
@@ -3,6 +3,10 @@ package foss
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	proxmox "github.com/luthermonson/go-proxmox"
@@ -71,7 +75,7 @@ func (r *realProxmoxAPI) ReadVM(ctx context.Context, vmid int) (*VMInfo, error) 
 	}
 	vm, err := node.VirtualMachine(ctx, vmid)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("proxmox: read vm %d: %w", vmid, err)
@@ -180,7 +184,7 @@ func (r *realProxmoxAPI) DeleteVM(ctx context.Context, vmid int) error {
 	}
 	vm, err := node.VirtualMachine(ctx, vmid)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil
 		}
 		return fmt.Errorf("proxmox: fetch vm %d for delete: %w", vmid, err)
@@ -213,7 +217,7 @@ func (r *realProxmoxAPI) ReadLXC(ctx context.Context, vmid int) (*LXCInfo, error
 	}
 	ct, err := node.Container(ctx, vmid)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("proxmox: read lxc %d: %w", vmid, err)
@@ -286,7 +290,7 @@ func (r *realProxmoxAPI) DeleteLXC(ctx context.Context, vmid int) error {
 	}
 	ct, err := node.Container(ctx, vmid)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil
 		}
 		return fmt.Errorf("proxmox: fetch lxc %d for delete: %w", vmid, err)
@@ -311,7 +315,7 @@ func (r *realProxmoxAPI) CreateStorage(ctx context.Context, opts []proxmox.Clust
 func (r *realProxmoxAPI) ReadStorage(ctx context.Context, name string) (*StorageInfo, error) {
 	s, err := r.client.ClusterStorage(ctx, name)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("proxmox: read storage %q: %w", name, err)
@@ -330,7 +334,7 @@ func (r *realProxmoxAPI) UpdateStorage(ctx context.Context, name string, opts []
 func (r *realProxmoxAPI) DeleteStorage(ctx context.Context, name string) error {
 	task, err := r.client.DeleteClusterStorage(ctx, name)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil
 		}
 		return fmt.Errorf("proxmox: delete storage %q: %w", name, err)
@@ -360,7 +364,7 @@ func (r *realProxmoxAPI) ReadNetwork(ctx context.Context, iface string) (*Networ
 	}
 	nw, err := node.Network(ctx, iface)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("proxmox: read network %q: %w", iface, err)
@@ -391,7 +395,7 @@ func (r *realProxmoxAPI) DeleteNetwork(ctx context.Context, iface string) error 
 	}
 	nw, err := node.Network(ctx, iface)
 	if err != nil {
-		if proxmox.IsNotFound(err) {
+		if notFoundErr(err) {
 			return nil
 		}
 		return fmt.Errorf("proxmox: fetch network %q for delete: %w", iface, err)
@@ -458,193 +462,1232 @@ func applyNetworkConfig(nw *proxmox.NodeNetwork, cfg NetworkConfig) {
 	}
 }
 
-// ── Firewall rules (stub) ───────────────────────────────────────────────────
+// ── Raw-REST helpers ────────────────────────────────────────────────────────
 
-func (r *realProxmoxAPI) CreateFirewallRule(_ context.Context, _ string, _ FirewallRuleInfo) (int, error) {
-	return 0, fmt.Errorf("proxmox: CreateFirewallRule not yet implemented")
-}
-
-func (r *realProxmoxAPI) ReadFirewallRule(_ context.Context, _ string, _ int) (*FirewallRuleInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadFirewallRule not yet implemented")
-}
-
-func (r *realProxmoxAPI) UpdateFirewallRule(_ context.Context, _ string, _ int, _ FirewallRuleInfo) error {
-	return fmt.Errorf("proxmox: UpdateFirewallRule not yet implemented")
-}
-
-func (r *realProxmoxAPI) DeleteFirewallRule(_ context.Context, _ string, _ int) error {
-	return fmt.Errorf("proxmox: DeleteFirewallRule not yet implemented")
-}
-
-// ── Snapshots (stub) ────────────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) CreateSnapshot(_ context.Context, _ int, _, _ string, _ bool) error {
-	return fmt.Errorf("proxmox: CreateSnapshot not yet implemented")
-}
-
-func (r *realProxmoxAPI) ReadSnapshot(_ context.Context, _ int, _ string) (*SnapshotInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadSnapshot not yet implemented")
-}
-
-func (r *realProxmoxAPI) DeleteSnapshot(_ context.Context, _ int, _ string) error {
-	return fmt.Errorf("proxmox: DeleteSnapshot not yet implemented")
+// notFoundErr reports whether err means the referenced object does not exist.
+// PVE surfaces missing objects as "500 <message>" HTTP statuses whose message
+// go-proxmox keeps only in the error text, so proxmox.IsNotFound alone is not
+// sufficient.
+func notFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if proxmox.IsNotFound(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"does not exist",
+		"doesn't exist",
+		"not found",
+		"no such",
+		"no rule at position",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
-// ── Pools (stub) ────────────────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) CreatePool(_ context.Context, _, _ string) error {
-	return fmt.Errorf("proxmox: CreatePool not yet implemented")
+func pveBool(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
-func (r *realProxmoxAPI) ReadPool(_ context.Context, _ string) (*PoolInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadPool not yet implemented")
+func splitCommaList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
-func (r *realProxmoxAPI) UpdatePool(_ context.Context, _, _ string) error {
-	return fmt.Errorf("proxmox: UpdatePool not yet implemented")
+// postTask issues a POST whose response is a task UPID and waits for it.
+func (r *realProxmoxAPI) postTask(ctx context.Context, path string, data interface{}) error {
+	var upid proxmox.UPID
+	if err := r.client.Post(ctx, path, data, &upid); err != nil {
+		return err
+	}
+	return r.wait(ctx, proxmox.NewTask(upid, r.client))
 }
 
-func (r *realProxmoxAPI) DeletePool(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeletePool not yet implemented")
+// deleteTask issues a DELETE whose response is a task UPID and waits for it.
+func (r *realProxmoxAPI) deleteTask(ctx context.Context, path string) error {
+	var upid proxmox.UPID
+	if err := r.client.Delete(ctx, path, &upid); err != nil {
+		return err
+	}
+	return r.wait(ctx, proxmox.NewTask(upid, r.client))
 }
 
-// ── Backup jobs (stub) ──────────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) CreateBackupJob(_ context.Context, _ BackupJobInfo) (string, error) {
-	return "", fmt.Errorf("proxmox: CreateBackupJob not yet implemented")
+// guestRef identifies a VM or container in the cluster.
+type guestRef struct {
+	Node string `json:"node"`
+	Type string `json:"type"` // "qemu" or "lxc"
+	VMID int    `json:"vmid"`
 }
 
-func (r *realProxmoxAPI) ReadBackupJob(_ context.Context, _ string) (*BackupJobInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadBackupJob not yet implemented")
+// findGuest locates vmid anywhere in the cluster; returns nil if absent.
+func (r *realProxmoxAPI) findGuest(ctx context.Context, vmid int) (*guestRef, error) {
+	var guests []guestRef
+	if err := r.client.Get(ctx, "/cluster/resources?type=vm", &guests); err != nil {
+		return nil, fmt.Errorf("proxmox: list cluster guests: %w", err)
+	}
+	for i := range guests {
+		if guests[i].VMID == vmid {
+			return &guests[i], nil
+		}
+	}
+	return nil, nil
 }
 
-func (r *realProxmoxAPI) UpdateBackupJob(_ context.Context, _ string, _ BackupJobInfo) error {
-	return fmt.Errorf("proxmox: UpdateBackupJob not yet implemented")
+// guestPath returns the API base path for vmid (e.g. "/nodes/pve/qemu/100"),
+// or a nil guestRef if the guest does not exist.
+func (r *realProxmoxAPI) guestPath(ctx context.Context, vmid int) (string, *guestRef, error) {
+	g, err := r.findGuest(ctx, vmid)
+	if err != nil {
+		return "", nil, err
+	}
+	if g == nil {
+		return "", nil, nil
+	}
+	return fmt.Sprintf("/nodes/%s/%s/%d", g.Node, g.Type, vmid), g, nil
 }
 
-func (r *realProxmoxAPI) DeleteBackupJob(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteBackupJob not yet implemented")
+// ── Firewall rules ──────────────────────────────────────────────────────────
+
+// firewallRulePayload always sends enable so rules can be toggled off.
+type firewallRulePayload struct {
+	Type    string `json:"type,omitempty"`
+	Action  string `json:"action,omitempty"`
+	Source  string `json:"source,omitempty"`
+	Dest    string `json:"dest,omitempty"`
+	Proto   string `json:"proto,omitempty"`
+	Dport   string `json:"dport,omitempty"`
+	Sport   string `json:"sport,omitempty"`
+	Enable  int    `json:"enable"`
+	Comment string `json:"comment,omitempty"`
+	Log     string `json:"log,omitempty"`
+	Macro   string `json:"macro,omitempty"`
+	Iface   string `json:"iface,omitempty"`
 }
 
-// ── SDN (stub) ──────────────────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) CreateSDNZone(_ context.Context, _ SDNZoneInfo) error {
-	return fmt.Errorf("proxmox: CreateSDNZone not yet implemented")
-}
-func (r *realProxmoxAPI) ReadSDNZone(_ context.Context, _ string) (*SDNZoneInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadSDNZone not yet implemented")
-}
-func (r *realProxmoxAPI) UpdateSDNZone(_ context.Context, _ string, _ SDNZoneInfo) error {
-	return fmt.Errorf("proxmox: UpdateSDNZone not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteSDNZone(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteSDNZone not yet implemented")
-}
-func (r *realProxmoxAPI) CreateSDNVnet(_ context.Context, _ SDNVnetInfo) error {
-	return fmt.Errorf("proxmox: CreateSDNVnet not yet implemented")
-}
-func (r *realProxmoxAPI) ReadSDNVnet(_ context.Context, _ string) (*SDNVnetInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadSDNVnet not yet implemented")
-}
-func (r *realProxmoxAPI) UpdateSDNVnet(_ context.Context, _ string, _ SDNVnetInfo) error {
-	return fmt.Errorf("proxmox: UpdateSDNVnet not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteSDNVnet(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteSDNVnet not yet implemented")
-}
-func (r *realProxmoxAPI) CreateSDNSubnet(_ context.Context, _ string, _ SDNSubnetInfo) error {
-	return fmt.Errorf("proxmox: CreateSDNSubnet not yet implemented")
-}
-func (r *realProxmoxAPI) ReadSDNSubnet(_ context.Context, _, _ string) (*SDNSubnetInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadSDNSubnet not yet implemented")
-}
-func (r *realProxmoxAPI) UpdateSDNSubnet(_ context.Context, _, _ string, _ SDNSubnetInfo) error {
-	return fmt.Errorf("proxmox: UpdateSDNSubnet not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteSDNSubnet(_ context.Context, _, _ string) error {
-	return fmt.Errorf("proxmox: DeleteSDNSubnet not yet implemented")
+func firewallPayload(rule FirewallRuleInfo) firewallRulePayload {
+	return firewallRulePayload{
+		Type:    rule.Type,
+		Action:  rule.Action,
+		Source:  rule.Source,
+		Dest:    rule.Dest,
+		Proto:   rule.Proto,
+		Dport:   rule.DPort,
+		Sport:   rule.SPort,
+		Enable:  pveBool(rule.Enable),
+		Comment: rule.Comment,
+		Log:     rule.Log,
+		Macro:   rule.Macro,
+		Iface:   rule.Iface,
+	}
 }
 
-// ── HA (stub) ───────────────────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) CreateHAGroup(_ context.Context, _ HAGroupInfo) error {
-	return fmt.Errorf("proxmox: CreateHAGroup not yet implemented")
-}
-func (r *realProxmoxAPI) ReadHAGroup(_ context.Context, _ string) (*HAGroupInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadHAGroup not yet implemented")
-}
-func (r *realProxmoxAPI) UpdateHAGroup(_ context.Context, _ string, _ HAGroupInfo) error {
-	return fmt.Errorf("proxmox: UpdateHAGroup not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteHAGroup(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteHAGroup not yet implemented")
-}
-func (r *realProxmoxAPI) CreateHAResource(_ context.Context, _ HAResourceInfo) error {
-	return fmt.Errorf("proxmox: CreateHAResource not yet implemented")
-}
-func (r *realProxmoxAPI) ReadHAResource(_ context.Context, _ string) (*HAResourceInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadHAResource not yet implemented")
-}
-func (r *realProxmoxAPI) UpdateHAResource(_ context.Context, _ string, _ HAResourceInfo) error {
-	return fmt.Errorf("proxmox: UpdateHAResource not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteHAResource(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteHAResource not yet implemented")
+// firewallBase maps a provider scope ("cluster", "<node>", "<node>/<vmid>")
+// to the API path holding its rules.
+func (r *realProxmoxAPI) firewallBase(ctx context.Context, scope string) (string, error) {
+	if scope == "cluster" {
+		return "/cluster/firewall", nil
+	}
+	if !strings.Contains(scope, "/") {
+		return "/nodes/" + url.PathEscape(scope) + "/firewall", nil
+	}
+	parts := strings.SplitN(scope, "/", 2)
+	vmid, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("proxmox: invalid firewall scope %q: %w", scope, err)
+	}
+	path, g, err := r.guestPath(ctx, vmid)
+	if err != nil {
+		return "", err
+	}
+	if g == nil {
+		// Worded so notFoundErr recognizes it on read/delete paths.
+		return "", fmt.Errorf("proxmox: firewall scope %q: vmid %d does not exist", scope, vmid)
+	}
+	return path + "/firewall", nil
 }
 
-// ── ACME (stub) ─────────────────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) CreateACMEAccount(_ context.Context, _ ACMEAccountInfo) error {
-	return fmt.Errorf("proxmox: CreateACMEAccount not yet implemented")
-}
-func (r *realProxmoxAPI) ReadACMEAccount(_ context.Context, _ string) (*ACMEAccountInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadACMEAccount not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteACMEAccount(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteACMEAccount not yet implemented")
-}
-
-// ── Users/Roles/ACLs (stub) ─────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) CreateUser(_ context.Context, _ PVEUserInfo) error {
-	return fmt.Errorf("proxmox: CreateUser not yet implemented")
-}
-func (r *realProxmoxAPI) ReadUser(_ context.Context, _ string) (*PVEUserInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadUser not yet implemented")
-}
-func (r *realProxmoxAPI) UpdateUser(_ context.Context, _ string, _ PVEUserInfo) error {
-	return fmt.Errorf("proxmox: UpdateUser not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteUser(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteUser not yet implemented")
-}
-func (r *realProxmoxAPI) CreateRole(_ context.Context, _ PVERoleInfo) error {
-	return fmt.Errorf("proxmox: CreateRole not yet implemented")
-}
-func (r *realProxmoxAPI) ReadRole(_ context.Context, _ string) (*PVERoleInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadRole not yet implemented")
-}
-func (r *realProxmoxAPI) UpdateRole(_ context.Context, _ string, _ PVERoleInfo) error {
-	return fmt.Errorf("proxmox: UpdateRole not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteRole(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteRole not yet implemented")
-}
-func (r *realProxmoxAPI) SetACL(_ context.Context, _ PVEACLInfo) error {
-	return fmt.Errorf("proxmox: SetACL not yet implemented")
-}
-func (r *realProxmoxAPI) ReadACL(_ context.Context, _ string) (*PVEACLInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadACL not yet implemented")
-}
-func (r *realProxmoxAPI) DeleteACL(_ context.Context, _ string) error {
-	return fmt.Errorf("proxmox: DeleteACL not yet implemented")
+func (r *realProxmoxAPI) CreateFirewallRule(ctx context.Context, scope string, rule FirewallRuleInfo) (int, error) {
+	base, err := r.firewallBase(ctx, scope)
+	if err != nil {
+		return 0, err
+	}
+	if err := r.client.Post(ctx, base+"/rules", firewallPayload(rule), nil); err != nil {
+		return 0, fmt.Errorf("proxmox: create firewall rule: %w", err)
+	}
+	// PVE inserts new rules at the top of the list.
+	return 0, nil
 }
 
-// ── Cluster options (stub) ──────────────────────────────────────────────────
-
-func (r *realProxmoxAPI) ReadClusterOptions(_ context.Context) (*ClusterOptionsInfo, error) {
-	return nil, fmt.Errorf("proxmox: ReadClusterOptions not yet implemented")
+func (r *realProxmoxAPI) ReadFirewallRule(ctx context.Context, scope string, pos int) (*FirewallRuleInfo, error) {
+	base, err := r.firewallBase(ctx, scope)
+	if err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var raw struct {
+		firewallRulePayload
+		Pos int `json:"pos"`
+	}
+	if err := r.client.Get(ctx, fmt.Sprintf("%s/rules/%d", base, pos), &raw); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read firewall rule %s/%d: %w", scope, pos, err)
+	}
+	return &FirewallRuleInfo{
+		Pos:     raw.Pos,
+		Type:    raw.Type,
+		Action:  raw.Action,
+		Source:  raw.Source,
+		Dest:    raw.Dest,
+		Proto:   raw.Proto,
+		DPort:   raw.Dport,
+		SPort:   raw.Sport,
+		Enable:  raw.Enable == 1,
+		Comment: raw.Comment,
+		Log:     raw.Log,
+		Macro:   raw.Macro,
+		Iface:   raw.Iface,
+	}, nil
 }
-func (r *realProxmoxAPI) UpdateClusterOptions(_ context.Context, _ ClusterOptionsInfo) error {
-	return fmt.Errorf("proxmox: UpdateClusterOptions not yet implemented")
+
+func (r *realProxmoxAPI) UpdateFirewallRule(ctx context.Context, scope string, pos int, rule FirewallRuleInfo) error {
+	base, err := r.firewallBase(ctx, scope)
+	if err != nil {
+		return err
+	}
+	if err := r.client.Put(ctx, fmt.Sprintf("%s/rules/%d", base, pos), firewallPayload(rule), nil); err != nil {
+		return fmt.Errorf("proxmox: update firewall rule %s/%d: %w", scope, pos, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) DeleteFirewallRule(ctx context.Context, scope string, pos int) error {
+	base, err := r.firewallBase(ctx, scope)
+	if err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return err
+	}
+	if err := r.client.Delete(ctx, fmt.Sprintf("%s/rules/%d", base, pos), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete firewall rule %s/%d: %w", scope, pos, err)
+	}
+	return nil
+}
+
+// ── Snapshots ───────────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateSnapshot(ctx context.Context, vmid int, name, description string, vmstate bool) error {
+	path, g, err := r.guestPath(ctx, vmid)
+	if err != nil {
+		return err
+	}
+	if g == nil {
+		return fmt.Errorf("proxmox: snapshot %q: vmid %d does not exist", name, vmid)
+	}
+	body := map[string]interface{}{"snapname": name}
+	if description != "" {
+		body["description"] = description
+	}
+	// Only QEMU snapshots can include RAM state.
+	if vmstate && g.Type == "qemu" {
+		body["vmstate"] = 1
+	}
+	if err := r.postTask(ctx, path+"/snapshot", body); err != nil {
+		return fmt.Errorf("proxmox: create snapshot %q on %d: %w", name, vmid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) ReadSnapshot(ctx context.Context, vmid int, name string) (*SnapshotInfo, error) {
+	path, g, err := r.guestPath(ctx, vmid)
+	if err != nil {
+		return nil, err
+	}
+	if g == nil {
+		return nil, nil
+	}
+	var snaps []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		VMState     int    `json:"vmstate"`
+	}
+	if err := r.client.Get(ctx, path+"/snapshot", &snaps); err != nil {
+		return nil, fmt.Errorf("proxmox: list snapshots for %d: %w", vmid, err)
+	}
+	for _, s := range snaps {
+		if s.Name == name {
+			return &SnapshotInfo{
+				Name: s.Name,
+				// PVE appends a trailing newline to descriptions.
+				Description: strings.TrimSpace(s.Description),
+				VMState:     s.VMState == 1,
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *realProxmoxAPI) DeleteSnapshot(ctx context.Context, vmid int, name string) error {
+	path, g, err := r.guestPath(ctx, vmid)
+	if err != nil {
+		return err
+	}
+	if g == nil {
+		return nil
+	}
+	if err := r.deleteTask(ctx, path+"/snapshot/"+url.PathEscape(name)); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete snapshot %q on %d: %w", name, vmid, err)
+	}
+	return nil
+}
+
+// ── Pools ───────────────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreatePool(ctx context.Context, poolid, comment string) error {
+	if err := r.client.NewPool(ctx, poolid, comment); err != nil {
+		return fmt.Errorf("proxmox: create pool %q: %w", poolid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) ReadPool(ctx context.Context, poolid string) (*PoolInfo, error) {
+	pool, err := r.client.Pool(ctx, poolid)
+	if err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read pool %q: %w", poolid, err)
+	}
+	return &PoolInfo{PoolID: poolid, Comment: pool.Comment}, nil
+}
+
+func (r *realProxmoxAPI) UpdatePool(ctx context.Context, poolid, comment string) error {
+	// Raw PUT so an empty comment actually clears the field.
+	body := map[string]string{"comment": comment}
+	if err := r.client.Put(ctx, "/pools/"+url.PathEscape(poolid), body, nil); err != nil {
+		return fmt.Errorf("proxmox: update pool %q: %w", poolid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) DeletePool(ctx context.Context, poolid string) error {
+	if err := r.client.Delete(ctx, "/pools/"+url.PathEscape(poolid), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete pool %q: %w", poolid, err)
+	}
+	return nil
+}
+
+// ── Backup jobs ─────────────────────────────────────────────────────────────
+
+// backupJobPayload always sends enabled so jobs can be toggled off.
+type backupJobPayload struct {
+	VMID         string `json:"vmid,omitempty"`
+	Storage      string `json:"storage,omitempty"`
+	Mode         string `json:"mode,omitempty"`
+	Compress     string `json:"compress,omitempty"`
+	Mailto       string `json:"mailto,omitempty"`
+	Schedule     string `json:"schedule,omitempty"`
+	Enabled      int    `json:"enabled"`
+	PruneBackups string `json:"prune-backups,omitempty"`
+}
+
+func backupPayload(job BackupJobInfo) backupJobPayload {
+	return backupJobPayload{
+		VMID:         job.VMID,
+		Storage:      job.Storage,
+		Mode:         job.Mode,
+		Compress:     job.Compress,
+		Mailto:       job.Mailto,
+		Schedule:     job.Schedule,
+		Enabled:      pveBool(job.Enabled),
+		PruneBackups: job.PruneBackups,
+	}
+}
+
+type backupJobRecord struct {
+	ID           string            `json:"id"`
+	VMID         string            `json:"vmid"`
+	Storage      string            `json:"storage"`
+	Mode         string            `json:"mode"`
+	Compress     string            `json:"compress"`
+	Mailto       string            `json:"mailto"`
+	Schedule     string            `json:"schedule"`
+	Enabled      proxmox.IntOrBool `json:"enabled"`
+	PruneBackups string            `json:"prune-backups"`
+}
+
+func (rec *backupJobRecord) toInfo() *BackupJobInfo {
+	return &BackupJobInfo{
+		ID:           rec.ID,
+		VMID:         rec.VMID,
+		Storage:      rec.Storage,
+		Mode:         rec.Mode,
+		Compress:     rec.Compress,
+		Mailto:       rec.Mailto,
+		Schedule:     rec.Schedule,
+		Enabled:      bool(rec.Enabled),
+		PruneBackups: rec.PruneBackups,
+	}
+}
+
+func (r *realProxmoxAPI) listBackupJobs(ctx context.Context) ([]backupJobRecord, error) {
+	var jobs []backupJobRecord
+	if err := r.client.Get(ctx, "/cluster/backup", &jobs); err != nil {
+		return nil, fmt.Errorf("proxmox: list backup jobs: %w", err)
+	}
+	return jobs, nil
+}
+
+func (r *realProxmoxAPI) CreateBackupJob(ctx context.Context, job BackupJobInfo) (string, error) {
+	// PVE autogenerates the job ID and the create call does not return it,
+	// so diff the job list around the create.
+	before, err := r.listBackupJobs(ctx)
+	if err != nil {
+		return "", err
+	}
+	seen := make(map[string]bool, len(before))
+	for _, j := range before {
+		seen[j.ID] = true
+	}
+	if err := r.client.Post(ctx, "/cluster/backup", backupPayload(job), nil); err != nil {
+		return "", fmt.Errorf("proxmox: create backup job: %w", err)
+	}
+	after, err := r.listBackupJobs(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, j := range after {
+		if !seen[j.ID] {
+			return j.ID, nil
+		}
+	}
+	return "", fmt.Errorf("proxmox: backup job created but its ID could not be determined")
+}
+
+func (r *realProxmoxAPI) ReadBackupJob(ctx context.Context, id string) (*BackupJobInfo, error) {
+	var rec backupJobRecord
+	if err := r.client.Get(ctx, "/cluster/backup/"+url.PathEscape(id), &rec); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read backup job %q: %w", id, err)
+	}
+	if rec.ID == "" {
+		rec.ID = id
+	}
+	return rec.toInfo(), nil
+}
+
+func (r *realProxmoxAPI) UpdateBackupJob(ctx context.Context, id string, job BackupJobInfo) error {
+	if err := r.client.Put(ctx, "/cluster/backup/"+url.PathEscape(id), backupPayload(job), nil); err != nil {
+		return fmt.Errorf("proxmox: update backup job %q: %w", id, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) DeleteBackupJob(ctx context.Context, id string) error {
+	if err := r.client.Delete(ctx, "/cluster/backup/"+url.PathEscape(id), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete backup job %q: %w", id, err)
+	}
+	return nil
+}
+
+// ── SDN ─────────────────────────────────────────────────────────────────────
+
+// applySDN commits pending SDN configuration changes cluster-wide.
+func (r *realProxmoxAPI) applySDN(ctx context.Context) error {
+	var upid proxmox.UPID
+	if err := r.client.Put(ctx, "/cluster/sdn", nil, &upid); err != nil {
+		return fmt.Errorf("proxmox: apply sdn config: %w", err)
+	}
+	return r.wait(ctx, proxmox.NewTask(upid, r.client))
+}
+
+type sdnZonePayload struct {
+	Zone       string `json:"zone,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Bridge     string `json:"bridge,omitempty"`
+	MTU        int    `json:"mtu,omitempty"`
+	Nodes      string `json:"nodes,omitempty"`
+	DNS        string `json:"dns,omitempty"`
+	ReverseDNS string `json:"reversedns,omitempty"`
+	DNSZone    string `json:"dnszone,omitempty"`
+	IPAM       string `json:"ipam,omitempty"`
+}
+
+func sdnZonePayloadFrom(zone SDNZoneInfo) sdnZonePayload {
+	return sdnZonePayload{
+		Zone:       zone.Zone,
+		Type:       zone.Type,
+		Bridge:     zone.Bridge,
+		MTU:        zone.MTU,
+		Nodes:      zone.Nodes,
+		DNS:        zone.DNS,
+		ReverseDNS: zone.ReverseDNS,
+		DNSZone:    zone.DNSZone,
+		IPAM:       zone.IPAM,
+	}
+}
+
+func (r *realProxmoxAPI) CreateSDNZone(ctx context.Context, zone SDNZoneInfo) error {
+	if err := r.client.Post(ctx, "/cluster/sdn/zones", sdnZonePayloadFrom(zone), nil); err != nil {
+		return fmt.Errorf("proxmox: create sdn zone %q: %w", zone.Zone, err)
+	}
+	return r.applySDN(ctx)
+}
+
+func (r *realProxmoxAPI) ReadSDNZone(ctx context.Context, zone string) (*SDNZoneInfo, error) {
+	var raw sdnZonePayload
+	if err := r.client.Get(ctx, "/cluster/sdn/zones/"+url.PathEscape(zone), &raw); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read sdn zone %q: %w", zone, err)
+	}
+	if raw.Zone == "" {
+		raw.Zone = zone
+	}
+	return &SDNZoneInfo{
+		Zone:       raw.Zone,
+		Type:       raw.Type,
+		Bridge:     raw.Bridge,
+		MTU:        raw.MTU,
+		Nodes:      raw.Nodes,
+		DNS:        raw.DNS,
+		ReverseDNS: raw.ReverseDNS,
+		DNSZone:    raw.DNSZone,
+		IPAM:       raw.IPAM,
+	}, nil
+}
+
+func (r *realProxmoxAPI) UpdateSDNZone(ctx context.Context, zone string, info SDNZoneInfo) error {
+	payload := sdnZonePayloadFrom(info)
+	// The zone id lives in the path and the type is immutable; PVE rejects
+	// both as body parameters on update.
+	payload.Zone = ""
+	payload.Type = ""
+	if err := r.client.Put(ctx, "/cluster/sdn/zones/"+url.PathEscape(zone), payload, nil); err != nil {
+		return fmt.Errorf("proxmox: update sdn zone %q: %w", zone, err)
+	}
+	return r.applySDN(ctx)
+}
+
+func (r *realProxmoxAPI) DeleteSDNZone(ctx context.Context, zone string) error {
+	if err := r.client.Delete(ctx, "/cluster/sdn/zones/"+url.PathEscape(zone), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete sdn zone %q: %w", zone, err)
+	}
+	return r.applySDN(ctx)
+}
+
+type sdnVnetPayload struct {
+	Vnet      string `json:"vnet,omitempty"`
+	Zone      string `json:"zone,omitempty"`
+	Tag       int    `json:"tag,omitempty"`
+	Alias     string `json:"alias,omitempty"`
+	VlanAware int    `json:"vlanaware,omitempty"`
+}
+
+func (r *realProxmoxAPI) CreateSDNVnet(ctx context.Context, vnet SDNVnetInfo) error {
+	payload := sdnVnetPayload{
+		Vnet:      vnet.Vnet,
+		Zone:      vnet.Zone,
+		Tag:       vnet.Tag,
+		Alias:     vnet.Alias,
+		VlanAware: pveBool(vnet.VlanAware),
+	}
+	if err := r.client.Post(ctx, "/cluster/sdn/vnets", payload, nil); err != nil {
+		return fmt.Errorf("proxmox: create sdn vnet %q: %w", vnet.Vnet, err)
+	}
+	return r.applySDN(ctx)
+}
+
+func (r *realProxmoxAPI) ReadSDNVnet(ctx context.Context, vnet string) (*SDNVnetInfo, error) {
+	var raw struct {
+		Vnet      string            `json:"vnet"`
+		Zone      string            `json:"zone"`
+		Tag       int               `json:"tag"`
+		Alias     string            `json:"alias"`
+		VlanAware proxmox.IntOrBool `json:"vlanaware"`
+	}
+	if err := r.client.Get(ctx, "/cluster/sdn/vnets/"+url.PathEscape(vnet), &raw); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read sdn vnet %q: %w", vnet, err)
+	}
+	if raw.Vnet == "" {
+		raw.Vnet = vnet
+	}
+	return &SDNVnetInfo{
+		Vnet:      raw.Vnet,
+		Zone:      raw.Zone,
+		Tag:       raw.Tag,
+		Alias:     raw.Alias,
+		VlanAware: bool(raw.VlanAware),
+	}, nil
+}
+
+func (r *realProxmoxAPI) UpdateSDNVnet(ctx context.Context, vnet string, info SDNVnetInfo) error {
+	payload := sdnVnetPayload{
+		Zone:      info.Zone,
+		Tag:       info.Tag,
+		Alias:     info.Alias,
+		VlanAware: pveBool(info.VlanAware),
+	}
+	if err := r.client.Put(ctx, "/cluster/sdn/vnets/"+url.PathEscape(vnet), payload, nil); err != nil {
+		return fmt.Errorf("proxmox: update sdn vnet %q: %w", vnet, err)
+	}
+	return r.applySDN(ctx)
+}
+
+func (r *realProxmoxAPI) DeleteSDNVnet(ctx context.Context, vnet string) error {
+	if err := r.client.Delete(ctx, "/cluster/sdn/vnets/"+url.PathEscape(vnet), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete sdn vnet %q: %w", vnet, err)
+	}
+	return r.applySDN(ctx)
+}
+
+// sdnSubnetRecord is a subnet as listed by PVE; Subnet holds the canonical
+// id (e.g. "zone-10.0.0.0-24") while CIDR holds the human form.
+type sdnSubnetRecord struct {
+	Subnet        string            `json:"subnet"`
+	CIDR          string            `json:"cidr"`
+	Vnet          string            `json:"vnet"`
+	Gateway       string            `json:"gateway"`
+	SNAT          proxmox.IntOrBool `json:"snat"`
+	DNSZonePrefix string            `json:"dnszoneprefix"`
+}
+
+// findSDNSubnet resolves a subnet by CIDR or canonical id; nil if absent.
+func (r *realProxmoxAPI) findSDNSubnet(ctx context.Context, vnet, subnet string) (*sdnSubnetRecord, error) {
+	var subs []sdnSubnetRecord
+	if err := r.client.Get(ctx, "/cluster/sdn/vnets/"+url.PathEscape(vnet)+"/subnets", &subs); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: list subnets of vnet %q: %w", vnet, err)
+	}
+	for i := range subs {
+		if subs[i].CIDR == subnet || subs[i].Subnet == subnet {
+			return &subs[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *realProxmoxAPI) CreateSDNSubnet(ctx context.Context, vnet string, subnet SDNSubnetInfo) error {
+	body := map[string]interface{}{
+		"subnet": subnet.Subnet,
+		"type":   "subnet",
+		"snat":   pveBool(subnet.SNAT),
+	}
+	if subnet.Gateway != "" {
+		body["gateway"] = subnet.Gateway
+	}
+	if subnet.DNSZonePrefix != "" {
+		body["dnszoneprefix"] = subnet.DNSZonePrefix
+	}
+	if err := r.client.Post(ctx, "/cluster/sdn/vnets/"+url.PathEscape(vnet)+"/subnets", body, nil); err != nil {
+		return fmt.Errorf("proxmox: create sdn subnet %q in vnet %q: %w", subnet.Subnet, vnet, err)
+	}
+	return r.applySDN(ctx)
+}
+
+func (r *realProxmoxAPI) ReadSDNSubnet(ctx context.Context, vnet, subnet string) (*SDNSubnetInfo, error) {
+	rec, err := r.findSDNSubnet(ctx, vnet, subnet)
+	if err != nil || rec == nil {
+		return nil, err
+	}
+	cidr := rec.CIDR
+	if cidr == "" {
+		cidr = rec.Subnet
+	}
+	info := &SDNSubnetInfo{
+		Subnet:        cidr,
+		Vnet:          vnet,
+		Gateway:       rec.Gateway,
+		SNAT:          bool(rec.SNAT),
+		DNSZonePrefix: rec.DNSZonePrefix,
+	}
+	if rec.Vnet != "" {
+		info.Vnet = rec.Vnet
+	}
+	return info, nil
+}
+
+func (r *realProxmoxAPI) UpdateSDNSubnet(ctx context.Context, vnet, subnet string, info SDNSubnetInfo) error {
+	rec, err := r.findSDNSubnet(ctx, vnet, subnet)
+	if err != nil {
+		return err
+	}
+	if rec == nil {
+		return fmt.Errorf("proxmox: sdn subnet %q in vnet %q does not exist", subnet, vnet)
+	}
+	body := map[string]interface{}{"snat": pveBool(info.SNAT)}
+	if info.Gateway != "" {
+		body["gateway"] = info.Gateway
+	}
+	if info.DNSZonePrefix != "" {
+		body["dnszoneprefix"] = info.DNSZonePrefix
+	}
+	path := "/cluster/sdn/vnets/" + url.PathEscape(vnet) + "/subnets/" + url.PathEscape(rec.Subnet)
+	if err := r.client.Put(ctx, path, body, nil); err != nil {
+		return fmt.Errorf("proxmox: update sdn subnet %q in vnet %q: %w", subnet, vnet, err)
+	}
+	return r.applySDN(ctx)
+}
+
+func (r *realProxmoxAPI) DeleteSDNSubnet(ctx context.Context, vnet, subnet string) error {
+	rec, err := r.findSDNSubnet(ctx, vnet, subnet)
+	if err != nil {
+		return err
+	}
+	if rec == nil {
+		return nil
+	}
+	path := "/cluster/sdn/vnets/" + url.PathEscape(vnet) + "/subnets/" + url.PathEscape(rec.Subnet)
+	if err := r.client.Delete(ctx, path, nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete sdn subnet %q in vnet %q: %w", subnet, vnet, err)
+	}
+	return r.applySDN(ctx)
+}
+
+// ── HA ──────────────────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateHAGroup(ctx context.Context, group HAGroupInfo) error {
+	body := map[string]interface{}{
+		"group":      group.Group,
+		"type":       "group",
+		"nodes":      group.Nodes,
+		"restricted": pveBool(group.Restricted),
+		"nofailback": pveBool(group.NoFailback),
+	}
+	if group.Comment != "" {
+		body["comment"] = group.Comment
+	}
+	if err := r.client.Post(ctx, "/cluster/ha/groups", body, nil); err != nil {
+		return fmt.Errorf("proxmox: create ha group %q: %w", group.Group, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) ReadHAGroup(ctx context.Context, group string) (*HAGroupInfo, error) {
+	var raw struct {
+		Group      string            `json:"group"`
+		Nodes      string            `json:"nodes"`
+		Restricted proxmox.IntOrBool `json:"restricted"`
+		NoFailback proxmox.IntOrBool `json:"nofailback"`
+		Comment    string            `json:"comment"`
+	}
+	if err := r.client.Get(ctx, "/cluster/ha/groups/"+url.PathEscape(group), &raw); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read ha group %q: %w", group, err)
+	}
+	if raw.Group == "" {
+		raw.Group = group
+	}
+	return &HAGroupInfo{
+		Group:      raw.Group,
+		Nodes:      raw.Nodes,
+		Restricted: bool(raw.Restricted),
+		NoFailback: bool(raw.NoFailback),
+		Comment:    raw.Comment,
+	}, nil
+}
+
+func (r *realProxmoxAPI) UpdateHAGroup(ctx context.Context, group string, info HAGroupInfo) error {
+	body := map[string]interface{}{
+		"nodes":      info.Nodes,
+		"restricted": pveBool(info.Restricted),
+		"nofailback": pveBool(info.NoFailback),
+	}
+	if info.Comment != "" {
+		body["comment"] = info.Comment
+	}
+	if err := r.client.Put(ctx, "/cluster/ha/groups/"+url.PathEscape(group), body, nil); err != nil {
+		return fmt.Errorf("proxmox: update ha group %q: %w", group, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) DeleteHAGroup(ctx context.Context, group string) error {
+	if err := r.client.Delete(ctx, "/cluster/ha/groups/"+url.PathEscape(group), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete ha group %q: %w", group, err)
+	}
+	return nil
+}
+
+func haResourceBody(info HAResourceInfo) map[string]interface{} {
+	body := map[string]interface{}{}
+	if info.Group != "" {
+		body["group"] = info.Group
+	}
+	if info.MaxRelocate != 0 {
+		body["max_relocate"] = info.MaxRelocate
+	}
+	if info.MaxRestart != 0 {
+		body["max_restart"] = info.MaxRestart
+	}
+	if info.State != "" {
+		body["state"] = info.State
+	}
+	if info.Comment != "" {
+		body["comment"] = info.Comment
+	}
+	return body
+}
+
+func (r *realProxmoxAPI) CreateHAResource(ctx context.Context, res HAResourceInfo) error {
+	body := haResourceBody(res)
+	body["sid"] = res.SID
+	if err := r.client.Post(ctx, "/cluster/ha/resources", body, nil); err != nil {
+		return fmt.Errorf("proxmox: create ha resource %q: %w", res.SID, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) ReadHAResource(ctx context.Context, sid string) (*HAResourceInfo, error) {
+	var raw struct {
+		SID         string `json:"sid"`
+		Group       string `json:"group"`
+		MaxRelocate int    `json:"max_relocate"`
+		MaxRestart  int    `json:"max_restart"`
+		State       string `json:"state"`
+		Comment     string `json:"comment"`
+	}
+	if err := r.client.Get(ctx, "/cluster/ha/resources/"+url.PathEscape(sid), &raw); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read ha resource %q: %w", sid, err)
+	}
+	if raw.SID == "" {
+		raw.SID = sid
+	}
+	return &HAResourceInfo{
+		SID:         raw.SID,
+		Group:       raw.Group,
+		MaxRelocate: raw.MaxRelocate,
+		MaxRestart:  raw.MaxRestart,
+		State:       raw.State,
+		Comment:     raw.Comment,
+	}, nil
+}
+
+func (r *realProxmoxAPI) UpdateHAResource(ctx context.Context, sid string, info HAResourceInfo) error {
+	if err := r.client.Put(ctx, "/cluster/ha/resources/"+url.PathEscape(sid), haResourceBody(info), nil); err != nil {
+		return fmt.Errorf("proxmox: update ha resource %q: %w", sid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) DeleteHAResource(ctx context.Context, sid string) error {
+	if err := r.client.Delete(ctx, "/cluster/ha/resources/"+url.PathEscape(sid), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete ha resource %q: %w", sid, err)
+	}
+	return nil
+}
+
+// ── ACME ────────────────────────────────────────────────────────────────────
+
+const defaultACMEDirectory = "https://acme-v02.api.letsencrypt.org/directory"
+
+func (r *realProxmoxAPI) CreateACMEAccount(ctx context.Context, acct ACMEAccountInfo) error {
+	directory := acct.Directory
+	if directory == "" {
+		directory = defaultACMEDirectory
+	}
+	// Registration requires agreeing to the directory's current TOS.
+	var tos string
+	if err := r.client.Get(ctx, "/cluster/acme/tos?directory="+url.QueryEscape(directory), &tos); err != nil {
+		return fmt.Errorf("proxmox: fetch acme tos for %q: %w", directory, err)
+	}
+	body := map[string]interface{}{
+		"name":      acct.Name,
+		"contact":   acct.Contact,
+		"directory": directory,
+	}
+	if tos != "" {
+		body["tos_url"] = tos
+	}
+	if err := r.postTask(ctx, "/cluster/acme/account", body); err != nil {
+		return fmt.Errorf("proxmox: create acme account %q: %w", acct.Name, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) ReadACMEAccount(ctx context.Context, name string) (*ACMEAccountInfo, error) {
+	var raw struct {
+		Account struct {
+			Contact []string `json:"contact"`
+		} `json:"account"`
+		Directory string `json:"directory"`
+	}
+	if err := r.client.Get(ctx, "/cluster/acme/account/"+url.PathEscape(name), &raw); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read acme account %q: %w", name, err)
+	}
+	contacts := make([]string, 0, len(raw.Account.Contact))
+	for _, c := range raw.Account.Contact {
+		contacts = append(contacts, strings.TrimPrefix(c, "mailto:"))
+	}
+	return &ACMEAccountInfo{
+		Name:      name,
+		Contact:   strings.Join(contacts, ","),
+		Directory: raw.Directory,
+	}, nil
+}
+
+func (r *realProxmoxAPI) DeleteACMEAccount(ctx context.Context, name string) error {
+	if err := r.deleteTask(ctx, "/cluster/acme/account/"+url.PathEscape(name)); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete acme account %q: %w", name, err)
+	}
+	return nil
+}
+
+// ── Users/Roles/ACLs ────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) CreateUser(ctx context.Context, user PVEUserInfo) error {
+	nu := &proxmox.NewUser{
+		UserID:    user.UserID,
+		Comment:   user.Comment,
+		Email:     user.Email,
+		Enable:    user.Enable,
+		Expire:    user.Expire,
+		Firstname: user.FirstName,
+		Lastname:  user.LastName,
+		Groups:    splitCommaList(user.Groups),
+	}
+	if err := r.client.NewUser(ctx, nu); err != nil {
+		return fmt.Errorf("proxmox: create user %q: %w", user.UserID, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) ReadUser(ctx context.Context, userid string) (*PVEUserInfo, error) {
+	u, err := r.client.User(ctx, userid)
+	if err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read user %q: %w", userid, err)
+	}
+	info := &PVEUserInfo{
+		UserID:    userid,
+		Email:     u.Email,
+		FirstName: u.Firstname,
+		LastName:  u.Lastname,
+		Groups:    strings.Join(u.Groups, ","),
+		Enable:    bool(u.Enable),
+		Expire:    u.Expire,
+		Comment:   u.Comment,
+	}
+	if u.UserID != "" {
+		info.UserID = u.UserID
+	}
+	return info, nil
+}
+
+func (r *realProxmoxAPI) UpdateUser(ctx context.Context, userid string, user PVEUserInfo) error {
+	// Raw PUT with enable always present so users can be disabled.
+	body := map[string]interface{}{"enable": pveBool(user.Enable)}
+	set := func(k, v string) {
+		if v != "" {
+			body[k] = v
+		}
+	}
+	set("email", user.Email)
+	set("firstname", user.FirstName)
+	set("lastname", user.LastName)
+	set("groups", user.Groups)
+	set("comment", user.Comment)
+	if user.Expire != 0 {
+		body["expire"] = user.Expire
+	}
+	if err := r.client.Put(ctx, "/access/users/"+url.PathEscape(userid), body, nil); err != nil {
+		return fmt.Errorf("proxmox: update user %q: %w", userid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) DeleteUser(ctx context.Context, userid string) error {
+	if err := r.client.Delete(ctx, "/access/users/"+url.PathEscape(userid), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete user %q: %w", userid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) CreateRole(ctx context.Context, role PVERoleInfo) error {
+	if err := r.client.NewRole(ctx, role.RoleID, role.Privs); err != nil {
+		return fmt.Errorf("proxmox: create role %q: %w", role.RoleID, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) ReadRole(ctx context.Context, roleid string) (*PVERoleInfo, error) {
+	// PVE returns a role as a map of privilege names to 1.
+	var privMap map[string]interface{}
+	if err := r.client.Get(ctx, "/access/roles/"+url.PathEscape(roleid), &privMap); err != nil {
+		if notFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("proxmox: read role %q: %w", roleid, err)
+	}
+	privs := make([]string, 0, len(privMap))
+	for p := range privMap {
+		privs = append(privs, p)
+	}
+	sort.Strings(privs)
+	return &PVERoleInfo{RoleID: roleid, Privs: strings.Join(privs, ",")}, nil
+}
+
+func (r *realProxmoxAPI) UpdateRole(ctx context.Context, roleid string, role PVERoleInfo) error {
+	body := map[string]interface{}{"privs": role.Privs}
+	if err := r.client.Put(ctx, "/access/roles/"+url.PathEscape(roleid), body, nil); err != nil {
+		return fmt.Errorf("proxmox: update role %q: %w", roleid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) DeleteRole(ctx context.Context, roleid string) error {
+	if err := r.client.Delete(ctx, "/access/roles/"+url.PathEscape(roleid), nil); err != nil {
+		if notFoundErr(err) {
+			return nil
+		}
+		return fmt.Errorf("proxmox: delete role %q: %w", roleid, err)
+	}
+	return nil
+}
+
+func (r *realProxmoxAPI) SetACL(ctx context.Context, acl PVEACLInfo) error {
+	body := map[string]interface{}{
+		"path":      acl.Path,
+		"roles":     acl.Roles,
+		"propagate": pveBool(acl.Propagate),
+	}
+	if acl.Users != "" {
+		body["users"] = acl.Users
+	}
+	if acl.Groups != "" {
+		body["groups"] = acl.Groups
+	}
+	if err := r.client.Put(ctx, "/access/acl", body, nil); err != nil {
+		return fmt.Errorf("proxmox: set acl on %q: %w", acl.Path, err)
+	}
+	return nil
+}
+
+// aclEntriesAt returns all ACL entries on exactly the given path.
+func (r *realProxmoxAPI) aclEntriesAt(ctx context.Context, path string) (proxmox.ACLs, error) {
+	acls, err := r.client.ACL(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("proxmox: list acls: %w", err)
+	}
+	var out proxmox.ACLs
+	for _, a := range acls {
+		if a.Path == path {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+func (r *realProxmoxAPI) ReadACL(ctx context.Context, path string) (*PVEACLInfo, error) {
+	entries, err := r.aclEntriesAt(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	userSet := map[string]bool{}
+	groupSet := map[string]bool{}
+	roleSet := map[string]bool{}
+	propagate := false
+	for _, a := range entries {
+		roleSet[a.RoleID] = true
+		switch a.Type {
+		case "user", "token":
+			userSet[a.UGID] = true
+		case "group":
+			groupSet[a.UGID] = true
+		}
+		if bool(a.Propagate) {
+			propagate = true
+		}
+	}
+	joinSorted := func(set map[string]bool) string {
+		keys := make([]string, 0, len(set))
+		for k := range set {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return strings.Join(keys, ",")
+	}
+	return &PVEACLInfo{
+		Path:      path,
+		Roles:     joinSorted(roleSet),
+		Users:     joinSorted(userSet),
+		Groups:    joinSorted(groupSet),
+		Propagate: propagate,
+	}, nil
+}
+
+func (r *realProxmoxAPI) DeleteACL(ctx context.Context, path string) error {
+	entries, err := r.aclEntriesAt(ctx, path)
+	if err != nil {
+		return err
+	}
+	// Remove entries role by role; PVE deletes matching (path, role, subject)
+	// tuples in one call per role.
+	byRole := map[string]*struct{ users, groups []string }{}
+	for _, a := range entries {
+		agg := byRole[a.RoleID]
+		if agg == nil {
+			agg = &struct{ users, groups []string }{}
+			byRole[a.RoleID] = agg
+		}
+		switch a.Type {
+		case "user", "token":
+			agg.users = append(agg.users, a.UGID)
+		case "group":
+			agg.groups = append(agg.groups, a.UGID)
+		}
+	}
+	for role, agg := range byRole {
+		body := map[string]interface{}{
+			"path":   path,
+			"roles":  role,
+			"delete": 1,
+		}
+		if len(agg.users) > 0 {
+			body["users"] = strings.Join(agg.users, ",")
+		}
+		if len(agg.groups) > 0 {
+			body["groups"] = strings.Join(agg.groups, ",")
+		}
+		if err := r.client.Put(ctx, "/access/acl", body, nil); err != nil {
+			return fmt.Errorf("proxmox: delete acl on %q (role %s): %w", path, role, err)
+		}
+	}
+	return nil
+}
+
+// ── Cluster options ─────────────────────────────────────────────────────────
+
+func (r *realProxmoxAPI) ReadClusterOptions(ctx context.Context) (*ClusterOptionsInfo, error) {
+	var raw struct {
+		Keyboard  string `json:"keyboard"`
+		Language  string `json:"language"`
+		EmailFrom string `json:"email_from"`
+		Migration string `json:"migration"`
+	}
+	if err := r.client.Get(ctx, "/cluster/options", &raw); err != nil {
+		return nil, fmt.Errorf("proxmox: read cluster options: %w", err)
+	}
+	info := &ClusterOptionsInfo{
+		Keyboard:  raw.Keyboard,
+		Language:  raw.Language,
+		EmailFrom: raw.EmailFrom,
+	}
+	// migration is a property string, e.g. "type=secure,network=10.0.0.0/24".
+	for _, part := range strings.Split(raw.Migration, ",") {
+		switch {
+		case strings.HasPrefix(part, "type="):
+			info.MigrationType = strings.TrimPrefix(part, "type=")
+		case strings.HasPrefix(part, "network="):
+			info.MigrationNetwork = strings.TrimPrefix(part, "network=")
+		case part == "secure" || part == "insecure":
+			info.MigrationType = part
+		}
+	}
+	return info, nil
+}
+
+func (r *realProxmoxAPI) UpdateClusterOptions(ctx context.Context, opts ClusterOptionsInfo) error {
+	body := map[string]interface{}{}
+	set := func(k, v string) {
+		if v != "" {
+			body[k] = v
+		}
+	}
+	set("keyboard", opts.Keyboard)
+	set("language", opts.Language)
+	set("email_from", opts.EmailFrom)
+	if opts.MigrationType != "" || opts.MigrationNetwork != "" {
+		typ := opts.MigrationType
+		if typ == "" {
+			typ = "secure"
+		}
+		migration := "type=" + typ
+		if opts.MigrationNetwork != "" {
+			migration += ",network=" + opts.MigrationNetwork
+		}
+		body["migration"] = migration
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	if err := r.client.Put(ctx, "/cluster/options", body, nil); err != nil {
+		return fmt.Errorf("proxmox: update cluster options: %w", err)
+	}
+	return nil
 }

--- a/providers/foss/proxmox_api_real.go
+++ b/providers/foss/proxmox_api_real.go
@@ -1008,17 +1008,8 @@ type sdnZonePayload struct {
 }
 
 func sdnZonePayloadFrom(zone SDNZoneInfo) sdnZonePayload {
-	return sdnZonePayload{
-		Zone:       zone.Zone,
-		Type:       zone.Type,
-		Bridge:     zone.Bridge,
-		MTU:        zone.MTU,
-		Nodes:      zone.Nodes,
-		DNS:        zone.DNS,
-		ReverseDNS: zone.ReverseDNS,
-		DNSZone:    zone.DNSZone,
-		IPAM:       zone.IPAM,
-	}
+	// Field-identical structs; direct conversion keeps them in lockstep.
+	return sdnZonePayload(zone)
 }
 
 func (r *realProxmoxAPI) CreateSDNZone(ctx context.Context, zone SDNZoneInfo) error {

--- a/providers/foss/proxmox_api_real.go
+++ b/providers/foss/proxmox_api_real.go
@@ -785,14 +785,73 @@ func (r *realProxmoxAPI) ReadPool(ctx context.Context, poolid string) (*PoolInfo
 		}
 		return nil, fmt.Errorf("proxmox: read pool %q: %w", poolid, err)
 	}
-	return &PoolInfo{PoolID: poolid, Comment: pool.Comment}, nil
+	return &PoolInfo{PoolID: poolid, Comment: pool.Comment, Members: poolMemberIDs(pool.Members)}, nil
 }
 
-func (r *realProxmoxAPI) UpdatePool(ctx context.Context, poolid, comment string) error {
+// poolMemberIDs extracts guest VMIDs from pool members, sorted ascending.
+func poolMemberIDs(members []proxmox.ClusterResource) string {
+	var ids []int
+	for _, m := range members {
+		if m.Type == "qemu" || m.Type == "lxc" {
+			ids = append(ids, int(m.VMID))
+		}
+	}
+	sort.Ints(ids)
+	strs := make([]string, len(ids))
+	for i, id := range ids {
+		strs[i] = strconv.Itoa(id)
+	}
+	return strings.Join(strs, ",")
+}
+
+func (r *realProxmoxAPI) UpdatePool(ctx context.Context, poolid, comment, members string) error {
 	// Raw PUT so an empty comment actually clears the field.
 	body := map[string]string{"comment": comment}
 	if err := r.client.Put(ctx, "/pools/"+url.PathEscape(poolid), body, nil); err != nil {
 		return fmt.Errorf("proxmox: update pool %q: %w", poolid, err)
+	}
+	if members == "" {
+		// Empty means unmanaged: leave existing membership alone.
+		return nil
+	}
+	// PVE membership is add/remove, not declarative; reconcile against the
+	// current member list.
+	pool, err := r.client.Pool(ctx, poolid)
+	if err != nil {
+		return fmt.Errorf("proxmox: read pool %q for member reconcile: %w", poolid, err)
+	}
+	currentSet := map[string]bool{}
+	for _, id := range splitCommaList(poolMemberIDs(pool.Members)) {
+		currentSet[id] = true
+	}
+	desiredSet := map[string]bool{}
+	for _, id := range splitCommaList(members) {
+		desiredSet[id] = true
+	}
+	var toAdd, toRemove []string
+	for id := range desiredSet {
+		if !currentSet[id] {
+			toAdd = append(toAdd, id)
+		}
+	}
+	for id := range currentSet {
+		if !desiredSet[id] {
+			toRemove = append(toRemove, id)
+		}
+	}
+	sort.Strings(toAdd)
+	sort.Strings(toRemove)
+	if len(toAdd) > 0 {
+		body := map[string]interface{}{"vms": strings.Join(toAdd, ",")}
+		if err := r.client.Put(ctx, "/pools/"+url.PathEscape(poolid), body, nil); err != nil {
+			return fmt.Errorf("proxmox: add members to pool %q: %w", poolid, err)
+		}
+	}
+	if len(toRemove) > 0 {
+		body := map[string]interface{}{"vms": strings.Join(toRemove, ","), "delete": 1}
+		if err := r.client.Put(ctx, "/pools/"+url.PathEscape(poolid), body, nil); err != nil {
+			return fmt.Errorf("proxmox: remove members from pool %q: %w", poolid, err)
+		}
 	}
 	return nil
 }
@@ -1405,6 +1464,7 @@ func (r *realProxmoxAPI) DeleteACMEAccount(ctx context.Context, name string) err
 func (r *realProxmoxAPI) CreateUser(ctx context.Context, user PVEUserInfo) error {
 	nu := &proxmox.NewUser{
 		UserID:    user.UserID,
+		Password:  user.Password,
 		Comment:   user.Comment,
 		Email:     user.Email,
 		Enable:    user.Enable,

--- a/providers/foss/proxmox_integration_test.go
+++ b/providers/foss/proxmox_integration_test.go
@@ -1,0 +1,335 @@
+//go:build integration
+
+package foss
+
+// Integration tests exercising the real Proxmox API end-to-end through the
+// provider. They only run with -tags integration and skip unless
+// PROXMOX_TEST_ENDPOINT is set:
+//
+//	PROXMOX_TEST_ENDPOINT=https://pve.example:8006 \
+//	PROXMOX_TEST_TOKEN_ID='root@pam!gecko' \
+//	PROXMOX_TEST_TOKEN_SECRET=... \
+//	PROXMOX_TEST_NODE=pve \
+//	PROXMOX_TEST_INSECURE=true \
+//	go test -tags integration -v -run TestIntegration ./providers/foss/
+//
+// Snapshot and VM-scoped firewall tests additionally need PROXMOX_TEST_VMID
+// pointing at an existing, snapshottable guest.
+//
+// All resources created here are prefixed "geckoit" and are deleted by the
+// tests themselves (with t.Cleanup as a safety net).
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/gecko-iac/gecko/internal/core"
+)
+
+func integrationProvider(t *testing.T) *ProxmoxProvider {
+	t.Helper()
+	endpoint := os.Getenv("PROXMOX_TEST_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("PROXMOX_TEST_ENDPOINT not set; skipping integration test")
+	}
+	node := os.Getenv("PROXMOX_TEST_NODE")
+	if node == "" {
+		node = "pve"
+	}
+	insecure, _ := strconv.ParseBool(os.Getenv("PROXMOX_TEST_INSECURE"))
+	return NewProxmoxProvider(map[string]interface{}{
+		"endpoint":     endpoint,
+		"token_id":     os.Getenv("PROXMOX_TEST_TOKEN_ID"),
+		"token_secret": os.Getenv("PROXMOX_TEST_TOKEN_SECRET"),
+		"node":         node,
+		"insecure":     insecure,
+	})
+}
+
+// cleanupState deletes state on test exit unless the test already did.
+func cleanupState(t *testing.T, p *ProxmoxProvider, state *core.ResourceState) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := p.Delete(context.Background(), state); err != nil {
+			t.Logf("cleanup of %s %q failed: %v", state.Type, state.ExternalID, err)
+		}
+	})
+}
+
+func TestIntegrationPoolLifecycle(t *testing.T) {
+	p := integrationProvider(t)
+	ctx := context.Background()
+
+	created, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:pool", Name: "geckoit-pool",
+		Inputs: core.Inputs{"comment": "gecko integration test"},
+	})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	cleanupState(t, p, created)
+
+	read, err := p.Read(ctx, created.ID, created.ExternalID)
+	if err != nil {
+		t.Fatalf("read pool: %v", err)
+	}
+	if read == nil {
+		t.Fatal("pool not found after create")
+	}
+	if read.Inputs["comment"] != "gecko integration test" {
+		t.Errorf("want comment round-tripped, got %v", read.Inputs["comment"])
+	}
+
+	updated, err := p.Update(ctx, created, core.ResourceArgs{
+		Type: "proxmox:pool", Name: "geckoit-pool",
+		Inputs: core.Inputs{"comment": "updated"},
+	})
+	if err != nil {
+		t.Fatalf("update pool: %v", err)
+	}
+	if updated.Inputs["comment"] != "updated" {
+		t.Errorf("want updated comment, got %v", updated.Inputs["comment"])
+	}
+
+	if err := p.Delete(ctx, created); err != nil {
+		t.Fatalf("delete pool: %v", err)
+	}
+	gone, err := p.Read(ctx, created.ID, created.ExternalID)
+	if err != nil {
+		t.Fatalf("read deleted pool: %v", err)
+	}
+	if gone != nil {
+		t.Errorf("pool still present after delete: %+v", gone)
+	}
+	// Second delete must be a no-op.
+	if err := p.Delete(ctx, created); err != nil {
+		t.Errorf("delete of already-deleted pool: %v", err)
+	}
+}
+
+func TestIntegrationRoleAndUserAndACLLifecycle(t *testing.T) {
+	p := integrationProvider(t)
+	ctx := context.Background()
+
+	role, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:role", Name: "geckoit-role",
+		Inputs: core.Inputs{"privs": "VM.Audit"},
+	})
+	if err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	cleanupState(t, p, role)
+
+	readRole, err := p.Read(ctx, role.ID, role.ExternalID)
+	if err != nil {
+		t.Fatalf("read role: %v", err)
+	}
+	if readRole == nil || readRole.Inputs["privs"] != "VM.Audit" {
+		t.Fatalf("role not round-tripped: %+v", readRole)
+	}
+
+	updatedRole, err := p.Update(ctx, role, core.ResourceArgs{
+		Type: "proxmox:role", Name: "geckoit-role",
+		Inputs: core.Inputs{"privs": "VM.Audit,VM.PowerMgmt"},
+	})
+	if err != nil {
+		t.Fatalf("update role: %v", err)
+	}
+	if updatedRole.Inputs["privs"] != "VM.Audit,VM.PowerMgmt" {
+		t.Errorf("want updated privs, got %v", updatedRole.Inputs["privs"])
+	}
+
+	user, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:user", Name: "geckoit",
+		Inputs: core.Inputs{"userid": "geckoit@pve", "enable": true, "comment": "gecko integration test"},
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	cleanupState(t, p, user)
+
+	readUser, err := p.Read(ctx, user.ID, user.ExternalID)
+	if err != nil {
+		t.Fatalf("read user: %v", err)
+	}
+	if readUser == nil || readUser.Inputs["enable"] != true {
+		t.Fatalf("user not round-tripped: %+v", readUser)
+	}
+
+	acl, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:acl", Name: "geckoit-acl",
+		Inputs: core.Inputs{"path": "/pool/geckoit-nonexistent", "roles": "geckoit-role", "users": "geckoit@pve", "propagate": true},
+	})
+	if err != nil {
+		t.Fatalf("create acl: %v", err)
+	}
+	cleanupState(t, p, acl)
+
+	readACL, err := p.Read(ctx, acl.ID, acl.ExternalID)
+	if err != nil {
+		t.Fatalf("read acl: %v", err)
+	}
+	if readACL == nil || readACL.Inputs["users"] != "geckoit@pve" {
+		t.Fatalf("acl not round-tripped: %+v", readACL)
+	}
+
+	// Tear down in dependency order and verify each is gone.
+	for _, state := range []*core.ResourceState{acl, user, role} {
+		if err := p.Delete(ctx, state); err != nil {
+			t.Fatalf("delete %s: %v", state.Type, err)
+		}
+		gone, err := p.Read(ctx, state.ID, state.ExternalID)
+		if err != nil {
+			t.Fatalf("read deleted %s: %v", state.Type, err)
+		}
+		if gone != nil {
+			t.Errorf("%s still present after delete", state.Type)
+		}
+	}
+}
+
+func TestIntegrationHAGroupLifecycle(t *testing.T) {
+	p := integrationProvider(t)
+	ctx := context.Background()
+
+	group, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:ha_group", Name: "geckoit-ha",
+		Inputs: core.Inputs{"nodes": p.node, "comment": "gecko integration test"},
+	})
+	if err != nil {
+		t.Fatalf("create ha group: %v", err)
+	}
+	cleanupState(t, p, group)
+
+	read, err := p.Read(ctx, group.ID, group.ExternalID)
+	if err != nil {
+		t.Fatalf("read ha group: %v", err)
+	}
+	if read == nil || read.Inputs["nodes"] != p.node {
+		t.Fatalf("ha group not round-tripped: %+v", read)
+	}
+
+	if err := p.Delete(ctx, group); err != nil {
+		t.Fatalf("delete ha group: %v", err)
+	}
+}
+
+func TestIntegrationBackupJobLifecycle(t *testing.T) {
+	p := integrationProvider(t)
+	ctx := context.Background()
+
+	storage := os.Getenv("PROXMOX_TEST_BACKUP_STORAGE")
+	if storage == "" {
+		storage = "local"
+	}
+
+	// Disabled job: registered with the scheduler but never runs.
+	job, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:backup", Name: "geckoit-backup",
+		Inputs: core.Inputs{"vmid": "all", "storage": storage, "mode": "snapshot", "schedule": "sat 03:00", "enabled": false},
+	})
+	if err != nil {
+		t.Fatalf("create backup job: %v", err)
+	}
+	cleanupState(t, p, job)
+	if job.ExternalID == "" {
+		t.Fatal("backup job created without an ID")
+	}
+
+	read, err := p.Read(ctx, job.ID, job.ExternalID)
+	if err != nil {
+		t.Fatalf("read backup job: %v", err)
+	}
+	if read == nil || read.Inputs["storage"] != storage {
+		t.Fatalf("backup job not round-tripped: %+v", read)
+	}
+	if read.Inputs["enabled"] != false {
+		t.Errorf("want job disabled, got %v", read.Inputs["enabled"])
+	}
+
+	if err := p.Delete(ctx, job); err != nil {
+		t.Fatalf("delete backup job: %v", err)
+	}
+}
+
+func TestIntegrationFirewallRuleLifecycle(t *testing.T) {
+	p := integrationProvider(t)
+	ctx := context.Background()
+
+	// Disabled cluster-level rule: inert even if the cluster firewall is on.
+	rule, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:firewall_rule", Name: "geckoit-rule",
+		Inputs: core.Inputs{"type": "in", "action": "ACCEPT", "proto": "tcp", "dport": "22222", "enable": false, "comment": "gecko integration test"},
+	})
+	if err != nil {
+		t.Fatalf("create firewall rule: %v", err)
+	}
+	cleanupState(t, p, rule)
+
+	read, err := p.Read(ctx, rule.ID, rule.ExternalID)
+	if err != nil {
+		t.Fatalf("read firewall rule: %v", err)
+	}
+	if read == nil || read.Inputs["dport"] != "22222" {
+		t.Fatalf("firewall rule not round-tripped: %+v", read)
+	}
+
+	if err := p.Delete(ctx, rule); err != nil {
+		t.Fatalf("delete firewall rule: %v", err)
+	}
+}
+
+func TestIntegrationSnapshotLifecycle(t *testing.T) {
+	p := integrationProvider(t)
+	ctx := context.Background()
+
+	vmidStr := os.Getenv("PROXMOX_TEST_VMID")
+	if vmidStr == "" {
+		t.Skip("PROXMOX_TEST_VMID not set; skipping snapshot test")
+	}
+	vmid, err := strconv.Atoi(vmidStr)
+	if err != nil {
+		t.Fatalf("invalid PROXMOX_TEST_VMID %q: %v", vmidStr, err)
+	}
+
+	snap, err := p.Create(ctx, core.ResourceArgs{
+		Type: "proxmox:snapshot", Name: "geckoit-snap",
+		Inputs: core.Inputs{"vmid": vmid, "description": "gecko integration test"},
+	})
+	if err != nil {
+		t.Fatalf("create snapshot: %v", err)
+	}
+	cleanupState(t, p, snap)
+	if want := fmt.Sprintf("%d/geckoit-snap", vmid); snap.ExternalID != want {
+		t.Errorf("want externalID %q, got %q", want, snap.ExternalID)
+	}
+
+	read, err := p.Read(ctx, snap.ID, snap.ExternalID)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if read == nil || read.Inputs["description"] != "gecko integration test" {
+		t.Fatalf("snapshot not round-tripped: %+v", read)
+	}
+
+	if err := p.Delete(ctx, snap); err != nil {
+		t.Fatalf("delete snapshot: %v", err)
+	}
+}
+
+func TestIntegrationClusterOptionsRead(t *testing.T) {
+	p := integrationProvider(t)
+
+	// Read-only: never mutate real cluster options from tests.
+	state, err := p.Read(context.Background(), "proxmox:cluster_options::cluster", "cluster")
+	if err != nil {
+		t.Fatalf("read cluster options: %v", err)
+	}
+	if state == nil {
+		t.Fatal("cluster options read returned nil")
+	}
+	t.Logf("cluster options: %+v", state.Inputs)
+}

--- a/providers/foss/proxmox_resources_test.go
+++ b/providers/foss/proxmox_resources_test.go
@@ -1,0 +1,699 @@
+package foss
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	proxmox "github.com/luthermonson/go-proxmox"
+
+	"github.com/gecko-iac/gecko/internal/core"
+)
+
+// ── notFoundErr ───────────────────────────────────────────────────────────────
+
+func TestProxmoxNotFoundErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"library sentinel", proxmox.ErrNotFound, true},
+		{"pve vm missing", errors.New("500 Configuration file 'nodes/pve/qemu-server/100.conf' does not exist"), true},
+		{"pve doesn't exist", errors.New("500 zone 'z1' doesn't exist"), true},
+		{"pve no such", errors.New("500 no such user ('nobody@pam')"), true},
+		{"pve job not found", errors.New("500 vzdump job 'backup-x' not found"), true},
+		{"firewall pos", errors.New("400 bad request: no rule at position 3"), true},
+		{"unrelated", errors.New("connection refused"), false},
+		{"auth", errors.New("not authorized to access endpoint"), false},
+	}
+	for _, tc := range cases {
+		if got := notFoundErr(tc.err); got != tc.want {
+			t.Errorf("%s: notFoundErr(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}
+
+// ── Firewall rules ────────────────────────────────────────────────────────────
+
+func TestProxmoxCreateFirewallRule_ClusterScope(t *testing.T) {
+	var gotScope string
+	p := newTestProvider(&mockProxmoxAPI{
+		createFirewallRule: func(_ context.Context, scope string, rule FirewallRuleInfo) (int, error) {
+			gotScope = scope
+			return 0, nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:firewall_rule", Name: "allow-ssh",
+		Inputs: core.Inputs{"type": "in", "action": "ACCEPT", "proto": "tcp", "dport": "22", "enable": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotScope != "cluster" {
+		t.Errorf("want scope %q, got %q", "cluster", gotScope)
+	}
+	if state.ExternalID != "cluster/0" {
+		t.Errorf("want externalID %q, got %q", "cluster/0", state.ExternalID)
+	}
+}
+
+func TestProxmoxCreateFirewallRule_VMScope_UsesProviderNode(t *testing.T) {
+	var gotScope string
+	p := newTestProvider(&mockProxmoxAPI{
+		createFirewallRule: func(_ context.Context, scope string, _ FirewallRuleInfo) (int, error) {
+			gotScope = scope
+			return 0, nil
+		},
+	})
+	_, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:firewall_rule", Name: "vm-rule",
+		Inputs: core.Inputs{"vmid": 100, "type": "in", "action": "DROP"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotScope != "pve/100" {
+		t.Errorf("want scope %q, got %q", "pve/100", gotScope)
+	}
+}
+
+func TestProxmoxCreateFirewallRule_NodeScope(t *testing.T) {
+	var gotScope string
+	p := newTestProvider(&mockProxmoxAPI{
+		createFirewallRule: func(_ context.Context, scope string, _ FirewallRuleInfo) (int, error) {
+			gotScope = scope
+			return 0, nil
+		},
+	})
+	_, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:firewall_rule", Name: "node-rule",
+		Inputs: core.Inputs{"node": "pve2", "type": "in", "action": "ACCEPT"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotScope != "pve2" {
+		t.Errorf("want scope %q, got %q", "pve2", gotScope)
+	}
+}
+
+func TestProxmoxReadFirewallRule_NotFound_ReturnsNil(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readFirewallRule: func(_ context.Context, _ string, _ int) (*FirewallRuleInfo, error) { return nil, nil },
+	})
+	state, err := p.Read(context.Background(), "proxmox:firewall_rule::allow-ssh", "cluster/0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != nil {
+		t.Errorf("want nil state for missing rule, got %+v", state)
+	}
+}
+
+func TestProxmoxReadFirewallRule_VMScope_ParsesExternalID(t *testing.T) {
+	var gotScope string
+	var gotPos int
+	p := newTestProvider(&mockProxmoxAPI{
+		readFirewallRule: func(_ context.Context, scope string, pos int) (*FirewallRuleInfo, error) {
+			gotScope, gotPos = scope, pos
+			return &FirewallRuleInfo{Pos: pos, Type: "in", Action: "ACCEPT", DPort: "22", Enable: true}, nil
+		},
+	})
+	state, err := p.Read(context.Background(), "proxmox:firewall_rule::allow-ssh", "pve/100/3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotScope != "pve/100" || gotPos != 3 {
+		t.Errorf("want scope pve/100 pos 3, got %s pos %d", gotScope, gotPos)
+	}
+	if state.Inputs["dport"] != "22" || state.Inputs["action"] != "ACCEPT" {
+		t.Errorf("inputs not mapped: %+v", state.Inputs)
+	}
+}
+
+func TestProxmoxDeleteFirewallRule_ParsesExternalID(t *testing.T) {
+	var gotScope string
+	var gotPos int
+	p := newTestProvider(&mockProxmoxAPI{
+		deleteFirewallRule: func(_ context.Context, scope string, pos int) error {
+			gotScope, gotPos = scope, pos
+			return nil
+		},
+	})
+	err := p.Delete(context.Background(), &core.ResourceState{
+		Type: "proxmox:firewall_rule", ExternalID: "cluster/2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotScope != "cluster" || gotPos != 2 {
+		t.Errorf("want cluster/2, got %s/%d", gotScope, gotPos)
+	}
+}
+
+// ── Snapshots ─────────────────────────────────────────────────────────────────
+
+func TestProxmoxCreateSnapshot_RequiresVMID(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{})
+	_, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:snapshot", Name: "pre-upgrade", Inputs: core.Inputs{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires vmid") {
+		t.Fatalf("want vmid-required error, got %v", err)
+	}
+}
+
+func TestProxmoxCreateSnapshot_NameFallbackAndExternalID(t *testing.T) {
+	var gotName string
+	var gotVMState bool
+	p := newTestProvider(&mockProxmoxAPI{
+		createSnapshot: func(_ context.Context, vmid int, name, _ string, vmstate bool) error {
+			gotName, gotVMState = name, vmstate
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:snapshot", Name: "pre-upgrade",
+		Inputs: core.Inputs{"vmid": 100, "vmstate": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotName != "pre-upgrade" || !gotVMState {
+		t.Errorf("want name pre-upgrade vmstate true, got %s %v", gotName, gotVMState)
+	}
+	if state.ExternalID != "100/pre-upgrade" {
+		t.Errorf("want externalID 100/pre-upgrade, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxReadSnapshot_NotFound_ReturnsNil(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readSnapshot: func(_ context.Context, _ int, _ string) (*SnapshotInfo, error) { return nil, nil },
+	})
+	state, err := p.Read(context.Background(), "proxmox:snapshot::pre-upgrade", "100/pre-upgrade")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != nil {
+		t.Errorf("want nil state for missing snapshot, got %+v", state)
+	}
+}
+
+func TestProxmoxUpdateSnapshot_ReturnsImmutableError(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{})
+	_, err := p.Update(context.Background(),
+		&core.ResourceState{Type: "proxmox:snapshot", ExternalID: "100/s1"},
+		core.ResourceArgs{Type: "proxmox:snapshot", Name: "s1"})
+	if err == nil || !strings.Contains(err.Error(), "immutable") {
+		t.Fatalf("want immutable error, got %v", err)
+	}
+}
+
+func TestProxmoxDeleteSnapshot_ParsesExternalID(t *testing.T) {
+	var gotVMID int
+	var gotName string
+	p := newTestProvider(&mockProxmoxAPI{
+		deleteSnapshot: func(_ context.Context, vmid int, name string) error {
+			gotVMID, gotName = vmid, name
+			return nil
+		},
+	})
+	err := p.Delete(context.Background(), &core.ResourceState{
+		Type: "proxmox:snapshot", ExternalID: "100/pre-upgrade",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotVMID != 100 || gotName != "pre-upgrade" {
+		t.Errorf("want 100/pre-upgrade, got %d/%s", gotVMID, gotName)
+	}
+}
+
+// ── Pools ─────────────────────────────────────────────────────────────────────
+
+func TestProxmoxCreatePool_NameFallback(t *testing.T) {
+	var gotPool, gotComment string
+	p := newTestProvider(&mockProxmoxAPI{
+		createPool: func(_ context.Context, poolid, comment string) error {
+			gotPool, gotComment = poolid, comment
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:pool", Name: "prod", Inputs: core.Inputs{"comment": "production"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPool != "prod" || gotComment != "production" {
+		t.Errorf("want prod/production, got %s/%s", gotPool, gotComment)
+	}
+	if state.ExternalID != "prod" {
+		t.Errorf("want externalID prod, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxReadPool_NotFound_ReturnsNil(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readPool: func(_ context.Context, _ string) (*PoolInfo, error) { return nil, nil },
+	})
+	state, err := p.Read(context.Background(), "proxmox:pool::prod", "prod")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != nil {
+		t.Errorf("want nil state for missing pool, got %+v", state)
+	}
+}
+
+func TestProxmoxUpdatePool_SendsComment(t *testing.T) {
+	var gotComment string
+	p := newTestProvider(&mockProxmoxAPI{
+		updatePool: func(_ context.Context, _, comment string) error {
+			gotComment = comment
+			return nil
+		},
+		readPool: func(_ context.Context, poolid string) (*PoolInfo, error) {
+			return &PoolInfo{PoolID: poolid, Comment: gotComment}, nil
+		},
+	})
+	state, err := p.Update(context.Background(),
+		&core.ResourceState{Type: "proxmox:pool", ExternalID: "prod"},
+		core.ResourceArgs{Type: "proxmox:pool", Name: "prod", Inputs: core.Inputs{"comment": "updated"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotComment != "updated" {
+		t.Errorf("want comment updated, got %q", gotComment)
+	}
+	if state.Inputs["comment"] != "updated" {
+		t.Errorf("state not refreshed: %+v", state.Inputs)
+	}
+}
+
+// ── Backup jobs ───────────────────────────────────────────────────────────────
+
+func TestProxmoxCreateBackupJob_StoresReturnedID(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		createBackupJob: func(_ context.Context, job BackupJobInfo) (string, error) {
+			if job.Storage != "local" || job.Schedule != "02:00" || !job.Enabled {
+				return "", errors.New("job fields not mapped")
+			}
+			return "backup-abc123", nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:backup", Name: "nightly",
+		Inputs: core.Inputs{"vmid": "all", "storage": "local", "schedule": "02:00", "enabled": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.ExternalID != "backup-abc123" {
+		t.Errorf("want externalID backup-abc123, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxReadBackupJob_MapsFields(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readBackupJob: func(_ context.Context, id string) (*BackupJobInfo, error) {
+			return &BackupJobInfo{ID: id, VMID: "100,101", Storage: "local", Mode: "snapshot", Enabled: true}, nil
+		},
+	})
+	state, err := p.Read(context.Background(), "proxmox:backup::nightly", "backup-abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.Inputs["vmid"] != "100,101" || state.Inputs["mode"] != "snapshot" {
+		t.Errorf("inputs not mapped: %+v", state.Inputs)
+	}
+	if state.Inputs["enabled"] != true {
+		t.Errorf("want enabled true, got %v", state.Inputs["enabled"])
+	}
+}
+
+func TestProxmoxDeleteBackupJob_UsesExternalID(t *testing.T) {
+	var gotID string
+	p := newTestProvider(&mockProxmoxAPI{
+		deleteBackupJob: func(_ context.Context, id string) error {
+			gotID = id
+			return nil
+		},
+	})
+	err := p.Delete(context.Background(), &core.ResourceState{Type: "proxmox:backup", ExternalID: "backup-abc123"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotID != "backup-abc123" {
+		t.Errorf("want backup-abc123, got %q", gotID)
+	}
+}
+
+// ── SDN ───────────────────────────────────────────────────────────────────────
+
+func TestProxmoxCreateSDNZone_NameFallback(t *testing.T) {
+	var got SDNZoneInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		createSDNZone: func(_ context.Context, zone SDNZoneInfo) error {
+			got = zone
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:sdn_zone", Name: "lab",
+		Inputs: core.Inputs{"type": "simple", "mtu": 1400},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Zone != "lab" || got.Type != "simple" || got.MTU != 1400 {
+		t.Errorf("zone not mapped: %+v", got)
+	}
+	if state.ExternalID != "lab" {
+		t.Errorf("want externalID lab, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxReadSDNZone_NotFound_ReturnsNil(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readSDNZone: func(_ context.Context, _ string) (*SDNZoneInfo, error) { return nil, nil },
+	})
+	state, err := p.Read(context.Background(), "proxmox:sdn_zone::lab", "lab")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != nil {
+		t.Errorf("want nil state, got %+v", state)
+	}
+}
+
+func TestProxmoxCreateSDNSubnet_ExternalIDCombinesVnet(t *testing.T) {
+	var gotVnet string
+	var gotInfo SDNSubnetInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		createSDNSubnet: func(_ context.Context, vnet string, info SDNSubnetInfo) error {
+			gotVnet, gotInfo = vnet, info
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:sdn_subnet", Name: "lab-subnet",
+		Inputs: core.Inputs{"vnet": "vnet1", "subnet": "10.0.0.0/24", "gateway": "10.0.0.1", "snat": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotVnet != "vnet1" || gotInfo.Subnet != "10.0.0.0/24" || !gotInfo.SNAT {
+		t.Errorf("subnet not mapped: vnet=%s info=%+v", gotVnet, gotInfo)
+	}
+	if state.ExternalID != "vnet1/10.0.0.0/24" {
+		t.Errorf("want externalID vnet1/10.0.0.0/24, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxDeleteSDNSubnet_ParsesExternalID(t *testing.T) {
+	var gotVnet, gotSubnet string
+	p := newTestProvider(&mockProxmoxAPI{
+		deleteSDNSubnet: func(_ context.Context, vnet, subnet string) error {
+			gotVnet, gotSubnet = vnet, subnet
+			return nil
+		},
+	})
+	err := p.Delete(context.Background(), &core.ResourceState{
+		Type: "proxmox:sdn_subnet", ExternalID: "vnet1/10.0.0.0/24",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotVnet != "vnet1" || gotSubnet != "10.0.0.0/24" {
+		t.Errorf("want vnet1 + 10.0.0.0/24, got %s + %s", gotVnet, gotSubnet)
+	}
+}
+
+// ── HA ────────────────────────────────────────────────────────────────────────
+
+func TestProxmoxCreateHAGroup_NameFallback(t *testing.T) {
+	var got HAGroupInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		createHAGroup: func(_ context.Context, group HAGroupInfo) error {
+			got = group
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:ha_group", Name: "critical",
+		Inputs: core.Inputs{"nodes": "pve1:2,pve2:1", "restricted": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Group != "critical" || got.Nodes != "pve1:2,pve2:1" || !got.Restricted {
+		t.Errorf("group not mapped: %+v", got)
+	}
+	if state.ExternalID != "critical" {
+		t.Errorf("want externalID critical, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxReadHAResource_MapsFields(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readHAResource: func(_ context.Context, sid string) (*HAResourceInfo, error) {
+			return &HAResourceInfo{SID: sid, Group: "critical", State: "started", MaxRestart: 2}, nil
+		},
+	})
+	state, err := p.Read(context.Background(), "proxmox:ha_resource::web", "vm:100")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.Inputs["group"] != "critical" || state.Inputs["state"] != "started" || state.Inputs["max_restart"] != 2 {
+		t.Errorf("inputs not mapped: %+v", state.Inputs)
+	}
+}
+
+// ── ACME ──────────────────────────────────────────────────────────────────────
+
+func TestProxmoxCreateACMEAccount_NameFallback(t *testing.T) {
+	var got ACMEAccountInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		createACMEAccount: func(_ context.Context, acct ACMEAccountInfo) error {
+			got = acct
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:acme_account", Name: "default",
+		Inputs: core.Inputs{"contact": "admin@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "default" || got.Contact != "admin@example.com" {
+		t.Errorf("account not mapped: %+v", got)
+	}
+	if state.ExternalID != "default" {
+		t.Errorf("want externalID default, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxUpdateACMEAccount_ReturnsImmutableError(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{})
+	_, err := p.Update(context.Background(),
+		&core.ResourceState{Type: "proxmox:acme_account", ExternalID: "default"},
+		core.ResourceArgs{Type: "proxmox:acme_account", Name: "default"})
+	if err == nil || !strings.Contains(err.Error(), "immutable") {
+		t.Fatalf("want immutable error, got %v", err)
+	}
+}
+
+// ── Users / Roles / ACLs ──────────────────────────────────────────────────────
+
+func TestProxmoxCreateUser_MapsFields(t *testing.T) {
+	var got PVEUserInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		createUser: func(_ context.Context, user PVEUserInfo) error {
+			got = user
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:user", Name: "deploy",
+		Inputs: core.Inputs{"userid": "deploy@pve", "email": "d@example.com", "enable": true, "groups": "admins"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.UserID != "deploy@pve" || got.Email != "d@example.com" || !got.Enable || got.Groups != "admins" {
+		t.Errorf("user not mapped: %+v", got)
+	}
+	if state.ExternalID != "deploy@pve" {
+		t.Errorf("want externalID deploy@pve, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxReadUser_NotFound_ReturnsNil(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readUser: func(_ context.Context, _ string) (*PVEUserInfo, error) { return nil, nil },
+	})
+	state, err := p.Read(context.Background(), "proxmox:user::deploy", "deploy@pve")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != nil {
+		t.Errorf("want nil state, got %+v", state)
+	}
+}
+
+func TestProxmoxCreateRole_NameFallback(t *testing.T) {
+	var got PVERoleInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		createRole: func(_ context.Context, role PVERoleInfo) error {
+			got = role
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:role", Name: "vm-operator",
+		Inputs: core.Inputs{"privs": "VM.Audit,VM.PowerMgmt"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RoleID != "vm-operator" || got.Privs != "VM.Audit,VM.PowerMgmt" {
+		t.Errorf("role not mapped: %+v", got)
+	}
+	if state.ExternalID != "vm-operator" {
+		t.Errorf("want externalID vm-operator, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxCreateACL_UsesPathAsExternalID(t *testing.T) {
+	var got PVEACLInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		setACL: func(_ context.Context, acl PVEACLInfo) error {
+			got = acl
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:acl", Name: "vm-access",
+		Inputs: core.Inputs{"path": "/vms/100", "roles": "PVEVMUser", "users": "deploy@pve", "propagate": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Path != "/vms/100" || got.Roles != "PVEVMUser" || got.Users != "deploy@pve" || !got.Propagate {
+		t.Errorf("acl not mapped: %+v", got)
+	}
+	if state.ExternalID != "/vms/100" {
+		t.Errorf("want externalID /vms/100, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxUpdateACL_ReturnsImmutableError(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{})
+	_, err := p.Update(context.Background(),
+		&core.ResourceState{Type: "proxmox:acl", ExternalID: "/vms/100"},
+		core.ResourceArgs{Type: "proxmox:acl", Name: "vm-access"})
+	if err == nil || !strings.Contains(err.Error(), "immutable") {
+		t.Fatalf("want immutable error, got %v", err)
+	}
+}
+
+// ── Cluster options ───────────────────────────────────────────────────────────
+
+func TestProxmoxCreateClusterOptions_CallsUpdate(t *testing.T) {
+	var got ClusterOptionsInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		updateClusterOptions: func(_ context.Context, opts ClusterOptionsInfo) error {
+			got = opts
+			return nil
+		},
+	})
+	state, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:cluster_options", Name: "cluster",
+		Inputs: core.Inputs{"email_from": "pve@example.com", "migration_type": "secure"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.EmailFrom != "pve@example.com" || got.MigrationType != "secure" {
+		t.Errorf("options not mapped: %+v", got)
+	}
+	if state.ExternalID != "cluster" {
+		t.Errorf("want externalID cluster, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxDeleteClusterOptions_IsNoOp(t *testing.T) {
+	// No mock fields set: any API call would panic.
+	p := newTestProvider(&mockProxmoxAPI{})
+	err := p.Delete(context.Background(), &core.ResourceState{Type: "proxmox:cluster_options", ExternalID: "cluster"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ── Diff coverage for new resource types ──────────────────────────────────────
+
+func TestProxmoxDiff_NewResourceTypes_DetectChanges(t *testing.T) {
+	cases := []struct {
+		rtype    core.ResourceType
+		field    string
+		oldValue interface{}
+		newValue interface{}
+	}{
+		{"proxmox:firewall_rule", "action", "ACCEPT", "DROP"},
+		{"proxmox:snapshot", "description", "before", "after"},
+		{"proxmox:pool", "comment", "a", "b"},
+		{"proxmox:backup", "schedule", "02:00", "03:00"},
+		{"proxmox:sdn_zone", "mtu", 1400, 1500},
+		{"proxmox:sdn_vnet", "tag", 10, 20},
+		{"proxmox:sdn_subnet", "gateway", "10.0.0.1", "10.0.0.254"},
+		{"proxmox:ha_group", "nodes", "pve1", "pve1,pve2"},
+		{"proxmox:ha_resource", "state", "started", "stopped"},
+		{"proxmox:acme_account", "contact", "a@example.com", "b@example.com"},
+		{"proxmox:user", "email", "a@example.com", "b@example.com"},
+		{"proxmox:role", "privs", "VM.Audit", "VM.Audit,VM.PowerMgmt"},
+		{"proxmox:acl", "roles", "PVEVMUser", "PVEAdmin"},
+		{"proxmox:cluster_options", "email_from", "a@example.com", "b@example.com"},
+	}
+	p := newTestProvider(&mockProxmoxAPI{})
+	ctx := context.Background()
+	for _, tc := range cases {
+		current := &core.ResourceState{Inputs: core.Inputs{tc.field: tc.oldValue}}
+		desired := core.ResourceArgs{Type: tc.rtype, Name: "x", Inputs: core.Inputs{tc.field: tc.newValue}}
+		diff, err := p.Diff(ctx, current, desired)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.rtype, err)
+		}
+		if diff.Kind != core.ChangeUpdate {
+			t.Errorf("%s: want ChangeUpdate on %s change, got %v", tc.rtype, tc.field, diff.Kind)
+		}
+	}
+}
+
+func TestProxmoxDiff_NewResourceTypes_NoChangeIsNoOp(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{})
+	ctx := context.Background()
+	types := []core.ResourceType{
+		"proxmox:firewall_rule", "proxmox:snapshot", "proxmox:pool", "proxmox:backup",
+		"proxmox:sdn_zone", "proxmox:sdn_vnet", "proxmox:sdn_subnet",
+		"proxmox:ha_group", "proxmox:ha_resource", "proxmox:acme_account",
+		"proxmox:user", "proxmox:role", "proxmox:acl", "proxmox:cluster_options",
+	}
+	for _, rt := range types {
+		inputs := core.Inputs{"comment": "same"}
+		diff, err := p.Diff(ctx, &core.ResourceState{Inputs: inputs}, core.ResourceArgs{Type: rt, Name: "x", Inputs: inputs})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", rt, err)
+		}
+		if diff.Kind != core.ChangeNoOp {
+			t.Errorf("%s: want ChangeNoOp, got %v", rt, diff.Kind)
+		}
+	}
+}

--- a/providers/foss/proxmox_resources_test.go
+++ b/providers/foss/proxmox_resources_test.go
@@ -274,7 +274,7 @@ func TestProxmoxReadPool_NotFound_ReturnsNil(t *testing.T) {
 func TestProxmoxUpdatePool_SendsComment(t *testing.T) {
 	var gotComment string
 	p := newTestProvider(&mockProxmoxAPI{
-		updatePool: func(_ context.Context, _, comment string) error {
+		updatePool: func(_ context.Context, _, comment, _ string) error {
 			gotComment = comment
 			return nil
 		},
@@ -293,6 +293,42 @@ func TestProxmoxUpdatePool_SendsComment(t *testing.T) {
 	}
 	if state.Inputs["comment"] != "updated" {
 		t.Errorf("state not refreshed: %+v", state.Inputs)
+	}
+}
+
+func TestProxmoxCreatePool_WithMembers_AssignsAfterCreate(t *testing.T) {
+	var gotMembers string
+	p := newTestProvider(&mockProxmoxAPI{
+		createPool: func(_ context.Context, _, _ string) error { return nil },
+		updatePool: func(_ context.Context, _, _, members string) error {
+			gotMembers = members
+			return nil
+		},
+	})
+	_, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:pool", Name: "prod",
+		Inputs: core.Inputs{"members": "100,101"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMembers != "100,101" {
+		t.Errorf("want members 100,101 assigned after create, got %q", gotMembers)
+	}
+}
+
+func TestProxmoxReadPool_MapsMembers(t *testing.T) {
+	p := newTestProvider(&mockProxmoxAPI{
+		readPool: func(_ context.Context, poolid string) (*PoolInfo, error) {
+			return &PoolInfo{PoolID: poolid, Members: "100,101"}, nil
+		},
+	})
+	state, err := p.Read(context.Background(), "proxmox:pool::prod", "prod")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.Inputs["members"] != "100,101" {
+		t.Errorf("want members mapped, got %v", state.Inputs["members"])
 	}
 }
 
@@ -532,6 +568,26 @@ func TestProxmoxCreateUser_MapsFields(t *testing.T) {
 	}
 	if state.ExternalID != "deploy@pve" {
 		t.Errorf("want externalID deploy@pve, got %q", state.ExternalID)
+	}
+}
+
+func TestProxmoxCreateUser_PassesPassword(t *testing.T) {
+	var got PVEUserInfo
+	p := newTestProvider(&mockProxmoxAPI{
+		createUser: func(_ context.Context, user PVEUserInfo) error {
+			got = user
+			return nil
+		},
+	})
+	_, err := p.Create(context.Background(), core.ResourceArgs{
+		Type: "proxmox:user", Name: "deploy",
+		Inputs: core.Inputs{"userid": "deploy@pve", "password": "s3cret", "enable": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Password != "s3cret" {
+		t.Errorf("want password passed through on create, got %q", got.Password)
 	}
 }
 

--- a/providers/foss/proxmox_test.go
+++ b/providers/foss/proxmox_test.go
@@ -50,7 +50,7 @@ type mockProxmoxAPI struct {
 
 	createPool func(ctx context.Context, poolid, comment string) error
 	readPool   func(ctx context.Context, poolid string) (*PoolInfo, error)
-	updatePool func(ctx context.Context, poolid, comment string) error
+	updatePool func(ctx context.Context, poolid, comment, members string) error
 	deletePool func(ctx context.Context, poolid string) error
 
 	createBackupJob func(ctx context.Context, job BackupJobInfo) (string, error)
@@ -180,8 +180,8 @@ func (m *mockProxmoxAPI) CreatePool(ctx context.Context, poolid, comment string)
 func (m *mockProxmoxAPI) ReadPool(ctx context.Context, poolid string) (*PoolInfo, error) {
 	return m.readPool(ctx, poolid)
 }
-func (m *mockProxmoxAPI) UpdatePool(ctx context.Context, poolid, comment string) error {
-	return m.updatePool(ctx, poolid, comment)
+func (m *mockProxmoxAPI) UpdatePool(ctx context.Context, poolid, comment, members string) error {
+	return m.updatePool(ctx, poolid, comment, members)
 }
 func (m *mockProxmoxAPI) DeletePool(ctx context.Context, poolid string) error {
 	return m.deletePool(ctx, poolid)


### PR DESCRIPTION
### Summary

PR #76 added 18 Proxmox resource types at the provider layer, but 14 of them were stubs in the real API layer — every call returned "not yet implemented". This PR implements them all against the live PVE REST API and brings test coverage up with them.

### Implementation

- **`proxmox:firewall_rule`** — cluster/node/guest scopes; guest rules auto-detect QEMU vs LXC via `/cluster/resources`
- **`proxmox:snapshot`** — QEMU + LXC; RAM state (`vmstate`) for QEMU guests
- **`proxmox:pool`** — including declarative `members` reconciled against PVE's add/remove membership API
- **`proxmox:backup`** — job ID recovered by diffing the job list around create (PVE doesn't return it)
- **`proxmox:sdn_zone` / `sdn_vnet` / `sdn_subnet`** — mutations commit the staged SDN config so changes go live
- **`proxmox:ha_group` / `ha_resource`**
- **`proxmox:acme_account`** — fetches and agrees to the directory's TOS on registration
- **`proxmox:user` / `role` / `acl`** — user supports write-only `password` on create
- **`proxmox:cluster_options`** — encodes/parses the `migration` property string

### Bug fix

PVE reports missing objects as `500 <message>` statuses, which `proxmox.IsNotFound` never matches — so reads of deleted resources errored instead of returning gone. All not-found checks (including the existing VM/LXC/storage/network paths) now go through a message-aware `notFoundErr` helper, and deletes of already-gone resources are no-ops.

### Tests

- Unit tests: 18 → 56, covering CRUD semantics for every resource type (scope resolution, externalID formats, name fallbacks, immutability, field mapping, diff detection)
- New env-gated integration suite (`-tags integration`) exercising the real API end-to-end with safe, self-cleaning `geckoit`-prefixed resources

### Closes

- Closes #22 — proxmox:firewall_rule
- Closes #23 — proxmox:snapshot
- Closes #24 — proxmox:pool
- Closes #25 — proxmox:backup
- Closes #26 — Proxmox advanced resources (SDN, HA, ACME, users)

### Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes (including `-tags integration`)
- [x] `go test ./...` passes (56 proxmox tests)
- [ ] Integration suite against a live PVE host

🤖 Generated with [Claude Code](https://claude.com/claude-code)