### PR TITLE
feat: real import (burrow), drift detection (crawl --refresh), TF normalization

### DIFF
--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gecko-iac/gecko/internal/lang"
 	"github.com/gecko-iac/gecko/internal/state"
 	"github.com/gecko-iac/gecko/internal/ui"
-	fossprovider "github.com/gecko-iac/gecko/providers/foss"
 )
 
 var crawlCmd = &Command{
@@ -33,6 +32,7 @@ committing. No changes are made during a crawl.`,
 		{Name: "json", Default: "false", Usage: "Output plan as JSON"},
 		{Name: "diff", Default: "true", Usage: "Show field-level diffs"},
 		{Name: "compact", Default: "false", Usage: "Compact output (no field diffs)"},
+		{Name: "refresh", Short: "r", Default: "false", Usage: "Read live state back from providers and report drift before planning"},
 	},
 	Run: runCrawl,
 }
@@ -69,71 +69,11 @@ func runCrawl(args []string, flags map[string]string) error {
 	// 2. Instantiate and configure providers
 	spin = ui.NewSpinner("Configuring providers")
 	spin.Start()
-	for _, hint := range loaded.ProviderHints {
-		lname := strings.ToLower(hint.Name)
-		switch lname {
-		case "proxmox":
-			p := fossprovider.NewProxmoxProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "fly":
-			p := fossprovider.NewFlyProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "openstack":
-			p := fossprovider.NewOpenStackProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "hostinger":
-			p := fossprovider.NewHostingerProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "ubicloud":
-			p := fossprovider.NewUbicloudProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "opennebula":
-			p := fossprovider.NewOpenNebulaProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		default:
-			spin.Stop(true)
-			ui.Warn(fmt.Sprintf("Unknown provider %q — skipping", hint.Name))
-			spin = ui.NewSpinner("Configuring providers")
-			spin.Start()
-		}
-	}
+	warnings := registerProviders(ctx, loaded)
 	spin.Stop(true)
+	for _, w := range warnings {
+		ui.Warn(w)
+	}
 
 	// 3. Load state backend
 	spin = ui.NewSpinner("Loading current state")
@@ -146,6 +86,60 @@ func runCrawl(args []string, flags map[string]string) error {
 	spin.Start()
 	engine := core.NewEngine(loaded.Stack, stateBackend)
 	spin.Stop(true)
+
+	// 4b. Optionally refresh state from providers and report drift
+	if flagSet(flags, "refresh") {
+		spin = ui.NewSpinner("Refreshing state from providers")
+		spin.Start()
+		refresh, err := engine.Refresh(ctx)
+		if err != nil {
+			spin.Stop(false)
+			ui.Error(fmt.Sprintf("Refresh failed: %s", err))
+			return err
+		}
+		spin.Stop(true)
+
+		if !outputJSON {
+			fmt.Println()
+			if len(refresh.Drifted) == 0 && len(refresh.Errors) == 0 {
+				ui.Info(fmt.Sprintf("No drift detected across %d resource(s) — state matches reality.", refresh.Checked))
+			}
+			if len(refresh.Drifted) > 0 {
+				ui.Header("Drift Detected")
+				fmt.Println()
+				for _, d := range refresh.Drifted {
+					rType, rName := splitResourceID(string(d.ResourceID))
+					resource := rType + "." + rName
+					if d.Missing {
+						fmt.Printf("  %s%s%s %smissing from provider%s\n",
+							ui.BrightWhite+ui.Bold, resource, ui.Reset,
+							ui.GeckoDanger, ui.Reset)
+						continue
+					}
+					fmt.Printf("  %s%s%s\n", ui.BrightWhite+ui.Bold, resource, ui.Reset)
+					for _, fc := range d.Changes {
+						if fc.Kind == core.ChangeDelete {
+							fmt.Printf("     %s%-45s%s %s%v%s → %s(unset)%s\n",
+								ui.GeckoMuted, fc.Field, ui.Reset,
+								ui.GeckoDanger, fc.OldValue, ui.Reset,
+								ui.GeckoWarning+ui.Italic, ui.Reset)
+							continue
+						}
+						fmt.Printf("     %s%-45s%s %s%v%s → %s%v%s\n",
+							ui.GeckoMuted, fc.Field, ui.Reset,
+							ui.GeckoDanger, fc.OldValue, ui.Reset,
+							ui.GeckoSuccess, fc.NewValue, ui.Reset)
+					}
+					fmt.Println()
+				}
+				ui.Info("Drifted resources are marked in state; run 'gecko grip' to reconcile them.")
+			}
+			for _, e := range refresh.Errors {
+				ui.Warn(fmt.Sprintf("refresh: %s", e))
+			}
+			fmt.Println()
+		}
+	}
 
 	spin = ui.NewSpinner("Calculating diffs")
 	spin.Start()

--- a/cmd/grip.go
+++ b/cmd/grip.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gecko-iac/gecko/internal/core"
 	"github.com/gecko-iac/gecko/internal/lang"
 	"github.com/gecko-iac/gecko/internal/ui"
-	fossprovider "github.com/gecko-iac/gecko/providers/foss"
 )
 
 var gripCmd = &Command{
@@ -63,71 +62,11 @@ func runGrip(args []string, flags map[string]string) error {
 	// 2. Configure providers
 	spin = ui.NewSpinner("Configuring providers")
 	spin.Start()
-	for _, hint := range loaded.ProviderHints {
-		lname := strings.ToLower(hint.Name)
-		switch lname {
-		case "proxmox":
-			p := fossprovider.NewProxmoxProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "fly":
-			p := fossprovider.NewFlyProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "openstack":
-			p := fossprovider.NewOpenStackProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "hostinger":
-			p := fossprovider.NewHostingerProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "ubicloud":
-			p := fossprovider.NewUbicloudProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		case "opennebula":
-			p := fossprovider.NewOpenNebulaProvider(hint.Config)
-			if err := p.Configure(ctx, hint.Config); err != nil {
-				spin.Stop(false)
-				ui.Warn(fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
-				spin = ui.NewSpinner("Configuring providers")
-				spin.Start()
-			}
-			loaded.Stack.RegisterProvider(p)
-		default:
-			spin.Stop(true)
-			ui.Warn(fmt.Sprintf("Unknown provider %q — skipping", hint.Name))
-			spin = ui.NewSpinner("Configuring providers")
-			spin.Start()
-		}
-	}
+	warnings := registerProviders(ctx, loaded)
 	spin.Stop(true)
+	for _, w := range warnings {
+		ui.Warn(w)
+	}
 
 	// 3. Load state backend
 	spin = ui.NewSpinner("Loading current state")

--- a/cmd/manage.go
+++ b/cmd/manage.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"sort"
 	"time"
 
+	"github.com/gecko-iac/gecko/internal/core"
+	"github.com/gecko-iac/gecko/internal/lang"
 	"github.com/gecko-iac/gecko/internal/ui"
 )
 
@@ -195,6 +199,7 @@ You will still need to add the resource declaration to your stack file.`,
 }
 
 func runBurrow(args []string, flags map[string]string) error {
+	ctx := context.Background()
 	ui.PrintBannerSmall("burrow")
 
 	if len(args) < 2 {
@@ -204,31 +209,105 @@ func runBurrow(args []string, flags map[string]string) error {
 		return fmt.Errorf("resource-type and external-id required")
 	}
 
-	resourceType := args[0]
+	resourceType := core.ResourceType(args[0])
 	externalID := args[1]
-	name := flagVal(flags, "name", externalID)
+	name := flagVal(flags, "name", "")
+	workspace := flagVal(flags, "workspace", "dev")
 	dryRun := flagSet(flags, "dry-run")
 
-	ui.Label("Resource Type", resourceType)
+	if name == "" {
+		ui.Error("--name is required")
+		return fmt.Errorf("--name is required")
+	}
+
+	ui.Label("Resource Type", string(resourceType))
 	ui.Label("External ID", externalID)
 	ui.Label("Local Name", name)
+	ui.Label("Workspace", workspace)
 	if dryRun {
 		ui.Label("Mode", ui.GeckoWarning+"dry-run (no state will be written)"+ui.Reset)
 	}
 	fmt.Println()
 
-	spin := ui.NewSpinner(fmt.Sprintf("Reading %s from provider", externalID))
+	// Load the project so provider credentials come from the stack config.
+	spin := ui.NewSpinner("Loading Scute project")
 	spin.Start()
-	time.Sleep(900 * time.Millisecond)
+	loaded, err := lang.LoadProject(lang.LoadOptions{Workspace: workspace})
+	if err != nil {
+		spin.Stop(false)
+		ui.Error(fmt.Sprintf("Failed to load project: %s", err))
+		return err
+	}
+	warnings := registerProviders(ctx, loaded)
+	spin.Stop(true)
+	for _, w := range warnings {
+		ui.Warn(w)
+	}
+
+	providerName := flagVal(flags, "provider", "")
+	if providerName == "" {
+		providerName = providerNameForResourceType(resourceType)
+	}
+	p, ok := loaded.Stack.GetProvider(providerName)
+	if !ok {
+		ui.Error(fmt.Sprintf("Provider %q is not configured in this project", providerName))
+		ui.Indent("Add a provider block to your stack file so gecko can reach it.")
+		fmt.Println()
+		return fmt.Errorf("provider %q not configured", providerName)
+	}
+
+	supported := false
+	for _, t := range p.SupportedTypes() {
+		if t == resourceType {
+			supported = true
+			break
+		}
+	}
+	if !supported {
+		ui.Error(fmt.Sprintf("Provider %q does not support resource type %q", providerName, resourceType))
+		return fmt.Errorf("unsupported resource type %q", resourceType)
+	}
+
+	spin = ui.NewSpinner(fmt.Sprintf("Reading %s from provider %s", externalID, providerName))
+	spin.Start()
+	imported, err := p.Import(ctx, resourceType, externalID)
+	if err != nil {
+		spin.Stop(false)
+		ui.Error(fmt.Sprintf("Import failed: %s", err))
+		return err
+	}
 	spin.Stop(true)
 
-	// Show what was read
+	if imported == nil {
+		ui.Error(fmt.Sprintf("No %s with external ID %q found at the provider", resourceType, externalID))
+		fmt.Println()
+		return fmt.Errorf("resource not found")
+	}
+
+	// Rebind the discovered state to the requested local identity.
+	id := core.ResourceID(fmt.Sprintf("%s::%s", resourceType, name))
+	imported.ID = id
+	imported.Type = resourceType
+	imported.Name = name
+	if imported.ExternalID == "" {
+		imported.ExternalID = externalID
+	}
+	if imported.CreatedAt.IsZero() {
+		imported.CreatedAt = time.Now()
+	}
+	imported.UpdatedAt = time.Now()
+
 	ui.Header("Discovered Resource State")
-	ui.Label("namespace", "default")
-	ui.Label("replicas", "2")
-	ui.Label("image", "nginx:1.25")
-	ui.Label("service_account", "default")
-	ui.Label("labels", "app=nginx, version=1.25")
+	ui.Label("status", string(imported.Status))
+	ui.Label("external_id", imported.ExternalID)
+	keys := make([]string, 0, len(imported.Inputs))
+	for k := range imported.Inputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		ui.Label(k, fmt.Sprintf("%v", imported.Inputs[k]))
+	}
 	fmt.Println()
 
 	if dryRun {
@@ -239,16 +318,44 @@ func runBurrow(args []string, flags map[string]string) error {
 
 	spin = ui.NewSpinner("Writing resource to Gecko state")
 	spin.Start()
-	time.Sleep(400 * time.Millisecond)
+
+	backend, backendType := loadBackend(loaded)
+	stackName := loaded.Stack.Name
+	if lockID, lockErr := backend.Lock(ctx, stackName, workspace); lockErr == nil {
+		defer func() { _ = backend.Unlock(ctx, stackName, workspace, lockID) }()
+	}
+
+	st, err := backend.Load(ctx, stackName, workspace)
+	if err != nil || st == nil {
+		st = &core.StackState{StackName: stackName, Workspace: workspace}
+	}
+	if st.Resources == nil {
+		st.Resources = make(map[core.ResourceID]*core.ResourceState)
+	}
+	if existing, exists := st.Resources[id]; exists {
+		spin.Stop(false)
+		ui.Error(fmt.Sprintf("Resource %s already exists in state (external ID %s)", id, existing.ExternalID))
+		ui.Indent("Choose a different --name or remove the existing resource first.")
+		fmt.Println()
+		return fmt.Errorf("resource %s already in state", id)
+	}
+
+	st.Resources[id] = imported
+	st.UpdatedAt = time.Now()
+	if err := backend.Save(ctx, stackName, workspace, st); err != nil {
+		spin.Stop(false)
+		ui.Error(fmt.Sprintf("Failed to write state: %s", err))
+		return err
+	}
 	spin.Stop(true)
 
 	fmt.Println()
-	fmt.Printf("  %s🕳️  Burrowed in!%s Resource %s%s/%s%s imported.\n\n",
+	fmt.Printf("  %s🕳️  Burrowed in!%s Resource %s%s/%s%s imported into %s state.\n\n",
 		ui.GeckoGreen+ui.Bold, ui.Reset,
-		ui.GeckoTeal, resourceType, name, ui.Reset)
+		ui.GeckoTeal, resourceType, name, ui.Reset, backendType)
 
-	ui.Warn("Remember to add this resource to your stack file to avoid drift.")
-	ui.Indent(fmt.Sprintf("stack.Resource(core.ResourceArgs{Type: %q, Name: %q, ...})", resourceType, name))
+	ui.Warn("Remember to add this resource to your stack file to avoid it being planned for destroy.")
+	ui.Indent(fmt.Sprintf("resource %q %q { ... }", resourceType, name))
 	fmt.Println()
 
 	return nil

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gecko-iac/gecko/internal/core"
+	"github.com/gecko-iac/gecko/internal/lang"
+	fossprovider "github.com/gecko-iac/gecko/providers/foss"
+)
+
+// providerFactories maps provider names to their constructors.
+var providerFactories = map[string]func(map[string]interface{}) core.Provider{
+	"proxmox":    func(c map[string]interface{}) core.Provider { return fossprovider.NewProxmoxProvider(c) },
+	"fly":        func(c map[string]interface{}) core.Provider { return fossprovider.NewFlyProvider(c) },
+	"openstack":  func(c map[string]interface{}) core.Provider { return fossprovider.NewOpenStackProvider(c) },
+	"hostinger":  func(c map[string]interface{}) core.Provider { return fossprovider.NewHostingerProvider(c) },
+	"ubicloud":   func(c map[string]interface{}) core.Provider { return fossprovider.NewUbicloudProvider(c) },
+	"opennebula": func(c map[string]interface{}) core.Provider { return fossprovider.NewOpenNebulaProvider(c) },
+}
+
+// registerProviders instantiates and configures every provider the project
+// declares, registering them on the stack. Configure failures and unknown
+// providers are returned as warnings rather than aborting, matching apply
+// behavior.
+func registerProviders(ctx context.Context, loaded *lang.LoadedStack) []string {
+	var warnings []string
+	for _, hint := range loaded.ProviderHints {
+		factory, ok := providerFactories[strings.ToLower(hint.Name)]
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("Unknown provider %q — skipping", hint.Name))
+			continue
+		}
+		p := factory(hint.Config)
+		if err := p.Configure(ctx, hint.Config); err != nil {
+			warnings = append(warnings, fmt.Sprintf("Provider %q configure warning: %s (continuing)", hint.Name, err))
+		}
+		loaded.Stack.RegisterProvider(p)
+	}
+	return warnings
+}
+
+// providerNameForResourceType extracts the provider name from a resource
+// type like "proxmox:vm".
+func providerNameForResourceType(t core.ResourceType) string {
+	if i := strings.Index(string(t), ":"); i > 0 {
+		return string(t)[:i]
+	}
+	return string(t)
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -452,6 +452,114 @@ func (e *Engine) Apply(ctx context.Context, plan *PlanResult, onProgress func(Re
 	return result, nil
 }
 
+// ─── Refresh / Drift Detection ────────────────────────────────────────────────
+
+// ResourceDrift describes how one resource diverges from recorded state.
+type ResourceDrift struct {
+	ResourceID ResourceID
+	Missing    bool          // resource no longer exists at the provider
+	Changes    []FieldChange // fields whose live values differ from state
+}
+
+// RefreshResult summarizes a read-back reconciliation pass.
+type RefreshResult struct {
+	StackName   string
+	Workspace   string
+	Checked     int
+	Drifted     []ResourceDrift
+	Errors      []string
+	RefreshedAt time.Time
+}
+
+// Refresh reads every resource in state back from its provider, compares the
+// live values against the recorded inputs, marks divergent resources with
+// StatusDrifted, and persists the updated statuses.
+func (e *Engine) Refresh(ctx context.Context) (*RefreshResult, error) {
+	result := &RefreshResult{
+		StackName:   e.stack.Name,
+		Workspace:   e.stack.Workspace,
+		RefreshedAt: time.Now(),
+	}
+
+	currentState, err := e.stateBackend.Load(ctx, e.stack.Name, e.stack.Workspace)
+	if err != nil || currentState == nil || len(currentState.Resources) == 0 {
+		return result, nil // nothing recorded yet — nothing can have drifted
+	}
+
+	ids := make([]string, 0, len(currentState.Resources))
+	for id := range currentState.Resources {
+		ids = append(ids, string(id))
+	}
+	sort.Strings(ids)
+
+	for _, idStr := range ids {
+		id := ResourceID(idStr)
+		rs := currentState.Resources[id]
+
+		p, ok := e.stack.GetProvider(providerNameForType(rs.Type))
+		if !ok {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: no provider registered", id))
+			continue
+		}
+		result.Checked++
+
+		actual, err := p.Read(ctx, id, rs.ExternalID)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", id, err))
+			continue
+		}
+
+		if actual == nil {
+			rs.Status = StatusDrifted
+			rs.Error = "resource missing from provider"
+			result.Drifted = append(result.Drifted, ResourceDrift{ResourceID: id, Missing: true})
+			continue
+		}
+
+		changes := driftChanges(rs.Inputs, actual.Inputs)
+		if len(changes) > 0 {
+			rs.Status = StatusDrifted
+			rs.Error = ""
+			result.Drifted = append(result.Drifted, ResourceDrift{ResourceID: id, Changes: changes})
+		} else if rs.Status == StatusDrifted {
+			// Previously drifted but now back in line.
+			rs.Status = StatusRunning
+			rs.Error = ""
+		}
+	}
+
+	if err := e.stateBackend.Save(ctx, e.stack.Name, e.stack.Workspace, currentState); err != nil {
+		return result, fmt.Errorf("saving refreshed state: %w", err)
+	}
+	return result, nil
+}
+
+// driftChanges compares recorded inputs against live values, restricted to
+// the recorded keys — provider-side defaults on undeclared fields are not
+// drift.
+func driftChanges(stored, live Inputs) []FieldChange {
+	fields := make([]string, 0, len(stored))
+	for f := range stored {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+
+	var changes []FieldChange
+	for _, f := range fields {
+		storedVal := stored[f]
+		liveVal, ok := live[f]
+		if !ok {
+			changes = append(changes, FieldChange{Field: f, Kind: ChangeDelete, OldValue: storedVal})
+			continue
+		}
+		// String comparison tolerates int/float64 wobble from JSON state round-trips.
+		if fmt.Sprintf("%v", storedVal) != fmt.Sprintf("%v", liveVal) {
+			changes = append(changes, FieldChange{Field: f, Kind: ChangeUpdate, OldValue: storedVal, NewValue: liveVal})
+		}
+	}
+	return changes
+}
+
 // providerNameForType extracts the provider name from a resource type like "proxmox:vm"
 func providerNameForType(t ResourceType) string {
 	s := string(t)

--- a/internal/core/engine_refresh_test.go
+++ b/internal/core/engine_refresh_test.go
@@ -1,0 +1,199 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// stubProvider implements Provider with a controllable Read.
+type stubProvider struct {
+	name string
+	read func(ctx context.Context, id ResourceID, externalID string) (*ResourceState, error)
+}
+
+func (s *stubProvider) Name() string                    { return s.name }
+func (s *stubProvider) Version() string                 { return "test" }
+func (s *stubProvider) SupportedTypes() []ResourceType  { return nil }
+func (s *stubProvider) Configure(context.Context, map[string]interface{}) error { return nil }
+func (s *stubProvider) Validate(context.Context, ResourceArgs) error            { return nil }
+func (s *stubProvider) Create(context.Context, ResourceArgs) (*ResourceState, error) {
+	return nil, nil
+}
+func (s *stubProvider) Read(ctx context.Context, id ResourceID, externalID string) (*ResourceState, error) {
+	return s.read(ctx, id, externalID)
+}
+func (s *stubProvider) Update(context.Context, *ResourceState, ResourceArgs) (*ResourceState, error) {
+	return nil, nil
+}
+func (s *stubProvider) Delete(context.Context, *ResourceState) error { return nil }
+func (s *stubProvider) Import(context.Context, ResourceType, string) (*ResourceState, error) {
+	return nil, nil
+}
+func (s *stubProvider) Diff(context.Context, *ResourceState, ResourceArgs) (*Diff, error) {
+	return &Diff{Kind: ChangeNoOp}, nil
+}
+
+// memBackend is an in-memory StateBackend.
+type memBackend struct {
+	state *StackState
+	saved int
+}
+
+func (m *memBackend) Load(context.Context, string, string) (*StackState, error) {
+	return m.state, nil
+}
+func (m *memBackend) Save(_ context.Context, _, _ string, s *StackState) error {
+	m.state = s
+	m.saved++
+	return nil
+}
+func (m *memBackend) Delete(context.Context, string, string) error { return nil }
+func (m *memBackend) List(context.Context) ([]string, error)       { return nil, nil }
+func (m *memBackend) Lock(context.Context, string, string) (string, error) {
+	return "lock", nil
+}
+func (m *memBackend) Unlock(context.Context, string, string, string) error { return nil }
+
+func refreshFixture(read func(ctx context.Context, id ResourceID, externalID string) (*ResourceState, error)) (*Engine, *memBackend) {
+	stack := NewStack("proj", "teststack", "dev")
+	stack.RegisterProvider(&stubProvider{name: "proxmox", read: read})
+	backend := &memBackend{
+		state: &StackState{
+			StackName: "teststack",
+			Workspace: "dev",
+			Resources: map[ResourceID]*ResourceState{
+				"proxmox:vm::web-01": {
+					ID:         "proxmox:vm::web-01",
+					Type:       "proxmox:vm",
+					Name:       "web-01",
+					Status:     StatusRunning,
+					ExternalID: "100",
+					Inputs:     Inputs{"memory": 2048, "cores": 2},
+					UpdatedAt:  time.Now(),
+				},
+			},
+		},
+	}
+	return NewEngine(stack, backend), backend
+}
+
+func TestRefresh_NoDrift_KeepsStatus(t *testing.T) {
+	engine, backend := refreshFixture(func(_ context.Context, id ResourceID, _ string) (*ResourceState, error) {
+		return &ResourceState{ID: id, Inputs: Inputs{"memory": 2048, "cores": 2, "extra": "ignored"}}, nil
+	})
+
+	result, err := engine.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Checked != 1 {
+		t.Errorf("want 1 checked, got %d", result.Checked)
+	}
+	if len(result.Drifted) != 0 {
+		t.Errorf("want no drift, got %+v", result.Drifted)
+	}
+	if backend.state.Resources["proxmox:vm::web-01"].Status != StatusRunning {
+		t.Errorf("status should stay running, got %v", backend.state.Resources["proxmox:vm::web-01"].Status)
+	}
+}
+
+func TestRefresh_ChangedField_MarksDrifted(t *testing.T) {
+	engine, backend := refreshFixture(func(_ context.Context, id ResourceID, _ string) (*ResourceState, error) {
+		return &ResourceState{ID: id, Inputs: Inputs{"memory": 4096, "cores": 2}}, nil
+	})
+
+	result, err := engine.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Drifted) != 1 {
+		t.Fatalf("want 1 drifted, got %d", len(result.Drifted))
+	}
+	drift := result.Drifted[0]
+	if drift.Missing {
+		t.Error("resource should not be marked missing")
+	}
+	if len(drift.Changes) != 1 || drift.Changes[0].Field != "memory" {
+		t.Fatalf("want memory change, got %+v", drift.Changes)
+	}
+	if backend.state.Resources["proxmox:vm::web-01"].Status != StatusDrifted {
+		t.Errorf("want StatusDrifted persisted, got %v", backend.state.Resources["proxmox:vm::web-01"].Status)
+	}
+	if backend.saved == 0 {
+		t.Error("refreshed state was not saved")
+	}
+}
+
+func TestRefresh_MissingResource_MarksDrifted(t *testing.T) {
+	engine, backend := refreshFixture(func(context.Context, ResourceID, string) (*ResourceState, error) {
+		return nil, nil // gone at the provider
+	})
+
+	result, err := engine.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Drifted) != 1 || !result.Drifted[0].Missing {
+		t.Fatalf("want 1 missing drift, got %+v", result.Drifted)
+	}
+	rs := backend.state.Resources["proxmox:vm::web-01"]
+	if rs.Status != StatusDrifted {
+		t.Errorf("want StatusDrifted, got %v", rs.Status)
+	}
+	if rs.Error == "" {
+		t.Error("want error message recorded on missing resource")
+	}
+}
+
+func TestRefresh_DriftResolved_RestoresRunning(t *testing.T) {
+	engine, backend := refreshFixture(func(_ context.Context, id ResourceID, _ string) (*ResourceState, error) {
+		return &ResourceState{ID: id, Inputs: Inputs{"memory": 2048, "cores": 2}}, nil
+	})
+	backend.state.Resources["proxmox:vm::web-01"].Status = StatusDrifted
+
+	result, err := engine.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Drifted) != 0 {
+		t.Fatalf("want no drift, got %+v", result.Drifted)
+	}
+	if backend.state.Resources["proxmox:vm::web-01"].Status != StatusRunning {
+		t.Errorf("want status restored to running, got %v", backend.state.Resources["proxmox:vm::web-01"].Status)
+	}
+}
+
+func TestRefresh_TypeMismatch_ComparesLoosely(t *testing.T) {
+	// JSON round-trips turn ints into float64; that must not read as drift.
+	engine, _ := refreshFixture(func(_ context.Context, id ResourceID, _ string) (*ResourceState, error) {
+		return &ResourceState{ID: id, Inputs: Inputs{"memory": float64(2048), "cores": float64(2)}}, nil
+	})
+
+	result, err := engine.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Drifted) != 0 {
+		t.Errorf("float64/int equivalence should not drift, got %+v", result.Drifted)
+	}
+}
+
+func TestRefresh_NoProvider_RecordsError(t *testing.T) {
+	engine, _ := refreshFixture(func(_ context.Context, id ResourceID, _ string) (*ResourceState, error) {
+		return &ResourceState{ID: id, Inputs: Inputs{}}, nil
+	})
+	// Sneak in a resource whose provider is not registered.
+	backend := engine.stateBackend.(*memBackend)
+	backend.state.Resources["unknown:thing::x"] = &ResourceState{
+		ID: "unknown:thing::x", Type: "unknown:thing", Inputs: Inputs{},
+	}
+
+	result, err := engine.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("want 1 error for unregistered provider, got %+v", result.Errors)
+	}
+}

--- a/internal/cross/terraform.go
+++ b/internal/cross/terraform.go
@@ -185,7 +185,295 @@ func normalizeTFInputs(tfType string, res *ImportedResource) {
 			res.Name = sanitizeName(name)
 		}
 		res.Inputs = clean
+
+	// ── Proxmox (telmate/proxmox) ────────────────────────────────────────────
+
+	case tfType == "proxmox_vm_qemu":
+		clean := pickInputs(attrs,
+			"name", "vmid", "memory", "cores", "sockets", "cpu", "ostype",
+			"onboot", "agent", "tags", "scsihw", "boot", "bios", "vga",
+			"ciuser", "cipassword", "ipconfig0", "sshkeys", "nameserver", "searchdomain")
+		renameInput(attrs, clean, "target_node", "node")
+		renameInput(attrs, clean, "desc", "description")
+		for i, net := range tfBlocks(attrs["network"]) {
+			if i > 3 {
+				break
+			}
+			if s := tfProxmoxNet(net); s != "" {
+				clean[fmt.Sprintf("net%d", i)] = s
+			}
+		}
+		for i, d := range tfBlocks(attrs["disk"]) {
+			if i > 3 {
+				break
+			}
+			spec := tfProxmoxDisk(d)
+			if spec == "" {
+				continue
+			}
+			slot := fmt.Sprintf("scsi%d", i)
+			if bus := tfString(d, "type"); bus != "" {
+				slot = fmt.Sprintf("%s%d", bus, tfInt(d, "slot"))
+			}
+			clean[slot] = spec
+		}
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "proxmox_lxc":
+		clean := pickInputs(attrs,
+			"hostname", "memory", "swap", "cores", "ostemplate", "unprivileged",
+			"onboot", "ssh_public_keys", "nameserver", "searchdomain", "tags", "description")
+		renameInput(attrs, clean, "target_node", "node")
+		if rf := tfBlocks(attrs["rootfs"]); len(rf) > 0 {
+			if spec := tfProxmoxDisk(rf[0]); spec != "" {
+				clean["rootfs"] = spec
+			}
+		}
+		for i, net := range tfBlocks(attrs["network"]) {
+			if i > 3 {
+				break
+			}
+			if s := tfProxmoxLXCNet(net); s != "" {
+				clean[fmt.Sprintf("net%d", i)] = s
+			}
+		}
+		if hostname, ok := attrs["hostname"].(string); ok {
+			res.Name = sanitizeName(hostname)
+		}
+		res.Inputs = clean
+
+	// ── Fly.io ───────────────────────────────────────────────────────────────
+
+	case tfType == "fly_app":
+		clean := pickInputs(attrs, "name", "org")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "fly_machine":
+		clean := pickInputs(attrs, "name", "app", "region", "image", "cpus", "env", "services")
+		renameInput(attrs, clean, "memorymb", "memory")
+		renameInput(attrs, clean, "cputype", "cpu_type")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "fly_volume":
+		clean := pickInputs(attrs, "name", "app", "region", "size")
+		renameInput(attrs, clean, "sizegb", "size")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	// ── OpenStack ────────────────────────────────────────────────────────────
+
+	case tfType == "openstack_compute_instance_v2":
+		clean := pickInputs(attrs,
+			"name", "flavor_id", "flavor_name", "image_id", "image_name",
+			"key_pair", "security_groups", "user_data", "availability_zone")
+		if networks := tfBlocks(attrs["network"]); len(networks) > 0 {
+			if uuid := tfString(networks[0], "uuid"); uuid != "" {
+				clean["network_id"] = uuid
+			}
+			if n := tfString(networks[0], "name"); n != "" {
+				clean["network"] = n
+			}
+		}
+		if bds := tfBlocks(attrs["block_device"]); len(bds) > 0 {
+			if uuid := tfString(bds[0], "uuid"); uuid != "" {
+				clean["image_id"] = uuid
+			}
+			if size := tfInt(bds[0], "volume_size"); size > 0 {
+				clean["volume_size"] = size
+			}
+		}
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "openstack_networking_network_v2":
+		clean := pickInputs(attrs, "name", "admin_state_up", "shared", "external")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "openstack_networking_subnet_v2":
+		clean := pickInputs(attrs, "name", "cidr", "ip_version", "gateway_ip", "enable_dhcp", "network_id")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "openstack_networking_secgroup_v2":
+		clean := pickInputs(attrs, "name", "description")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "openstack_blockstorage_volume_v3":
+		clean := pickInputs(attrs, "name", "size", "description", "volume_type")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	// ── OpenNebula ───────────────────────────────────────────────────────────
+
+	case tfType == "opennebula_virtual_machine":
+		clean := pickInputs(attrs, "name", "cpu", "vcpu", "memory", "template_id", "group")
+		if disks := tfBlocks(attrs["disk"]); len(disks) > 0 {
+			if _, ok := disks[0]["image_id"]; ok {
+				clean["image_id"] = tfInt(disks[0], "image_id")
+			}
+			if size := tfInt(disks[0], "size"); size > 0 {
+				clean["disk_size"] = size
+			}
+		}
+		if nics := tfBlocks(attrs["nic"]); len(nics) > 0 {
+			if _, ok := nics[0]["network_id"]; ok {
+				clean["network_id"] = tfInt(nics[0], "network_id")
+			}
+		}
+		if ctxBlock, ok := attrs["context"].(map[string]interface{}); ok {
+			clean["context"] = ctxBlock
+		}
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "opennebula_virtual_network":
+		clean := pickInputs(attrs, "name", "bridge", "physical_device", "vlan_id", "permissions")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
+
+	case tfType == "opennebula_image":
+		clean := pickInputs(attrs, "name", "datastore_id", "path", "persistent", "type")
+		if name, ok := attrs["name"].(string); ok {
+			res.Name = sanitizeName(name)
+		}
+		res.Inputs = clean
 	}
+}
+
+// ── Normalization helpers ─────────────────────────────────────────────────────
+
+// pickInputs copies the listed keys from attrs into a fresh input map.
+func pickInputs(attrs map[string]interface{}, keys ...string) map[string]interface{} {
+	clean := make(map[string]interface{})
+	for _, k := range keys {
+		if v, ok := attrs[k]; ok {
+			clean[k] = v
+		}
+	}
+	return clean
+}
+
+// renameInput copies attrs[from] into clean[to] when present.
+func renameInput(attrs, clean map[string]interface{}, from, to string) {
+	if v, ok := attrs[from]; ok {
+		clean[to] = v
+	}
+}
+
+// tfBlocks returns nested block(s) as a slice of maps, handling both the
+// single-block (map) and repeated-block (slice) shapes flattenTFAttrs produces.
+func tfBlocks(v interface{}) []map[string]interface{} {
+	switch b := v.(type) {
+	case map[string]interface{}:
+		return []map[string]interface{}{b}
+	case []interface{}:
+		var out []map[string]interface{}
+		for _, el := range b {
+			if m, ok := el.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func tfString(m map[string]interface{}, k string) string {
+	v, _ := m[k].(string)
+	return v
+}
+
+func tfInt(m map[string]interface{}, k string) int {
+	switch v := m[k].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	}
+	return 0
+}
+
+// tfProxmoxNet renders a telmate network block as a PVE net string,
+// e.g. "virtio,bridge=vmbr0,tag=10".
+func tfProxmoxNet(m map[string]interface{}) string {
+	model := tfString(m, "model")
+	if model == "" {
+		model = "virtio"
+	}
+	s := model
+	if b := tfString(m, "bridge"); b != "" {
+		s += ",bridge=" + b
+	}
+	if tag := tfInt(m, "tag"); tag > 0 {
+		s += fmt.Sprintf(",tag=%d", tag)
+	}
+	if fw, ok := m["firewall"].(bool); ok && fw {
+		s += ",firewall=1"
+	}
+	return s
+}
+
+// tfProxmoxLXCNet renders a telmate LXC network block as a PVE net string,
+// e.g. "name=eth0,bridge=vmbr0,ip=dhcp".
+func tfProxmoxLXCNet(m map[string]interface{}) string {
+	var parts []string
+	if n := tfString(m, "name"); n != "" {
+		parts = append(parts, "name="+n)
+	}
+	if b := tfString(m, "bridge"); b != "" {
+		parts = append(parts, "bridge="+b)
+	}
+	if ip := tfString(m, "ip"); ip != "" {
+		parts = append(parts, "ip="+ip)
+	}
+	if gw := tfString(m, "gw"); gw != "" {
+		parts = append(parts, "gw="+gw)
+	}
+	if tag := tfInt(m, "tag"); tag > 0 {
+		parts = append(parts, fmt.Sprintf("tag=%d", tag))
+	}
+	return strings.Join(parts, ",")
+}
+
+// tfProxmoxDisk renders a telmate disk/rootfs block as a PVE volume spec,
+// e.g. "local-lvm:20".
+func tfProxmoxDisk(m map[string]interface{}) string {
+	storage := tfString(m, "storage")
+	if storage == "" {
+		return ""
+	}
+	size := strings.TrimRight(tfString(m, "size"), "Gg")
+	if size == "" {
+		return storage
+	}
+	return storage + ":" + size
 }
 
 // sanitizeName converts an arbitrary string into a valid Scute resource name.

--- a/internal/cross/terraform_test.go
+++ b/internal/cross/terraform_test.go
@@ -1,0 +1,194 @@
+package cross
+
+import (
+	"testing"
+)
+
+func normalize(tfType string, attrs map[string]interface{}) *ImportedResource {
+	res := &ImportedResource{
+		SourceKind: SourceTerraform,
+		SourceType: tfType,
+		GeckoType:  MapTerraformType(tfType),
+		Name:       "raw-name",
+		Inputs:     attrs,
+	}
+	normalizeTFInputs(tfType, res)
+	return res
+}
+
+func TestNormalizeTF_ProxmoxVM(t *testing.T) {
+	res := normalize("proxmox_vm_qemu", map[string]interface{}{
+		"name":        "web-01",
+		"target_node": "pve",
+		"vmid":        float64(100),
+		"memory":      float64(2048),
+		"cores":       float64(2),
+		"desc":        "web server",
+		"agent":       float64(1),
+		"ciuser":      "admin",
+		"ipconfig0":   "ip=10.0.0.5/24,gw=10.0.0.1",
+		"network": map[string]interface{}{ // single flattened block
+			"model":    "virtio",
+			"bridge":   "vmbr0",
+			"tag":      float64(10),
+			"firewall": true,
+		},
+		"disk": map[string]interface{}{
+			"type":    "scsi",
+			"slot":    float64(0),
+			"storage": "local-lvm",
+			"size":    "20G",
+		},
+		"unwanted_attr": "should be dropped",
+	})
+
+	if res.Name != "web-01" {
+		t.Errorf("want name web-01, got %q", res.Name)
+	}
+	if res.Inputs["node"] != "pve" {
+		t.Errorf("want target_node renamed to node, got %v", res.Inputs["node"])
+	}
+	if res.Inputs["description"] != "web server" {
+		t.Errorf("want desc renamed to description, got %v", res.Inputs["description"])
+	}
+	if res.Inputs["net0"] != "virtio,bridge=vmbr0,tag=10,firewall=1" {
+		t.Errorf("net0 not composed: %v", res.Inputs["net0"])
+	}
+	if res.Inputs["scsi0"] != "local-lvm:20" {
+		t.Errorf("scsi0 not composed: %v", res.Inputs["scsi0"])
+	}
+	if _, ok := res.Inputs["unwanted_attr"]; ok {
+		t.Error("unlisted attributes should be dropped")
+	}
+}
+
+func TestNormalizeTF_ProxmoxVM_MultipleNetworks(t *testing.T) {
+	res := normalize("proxmox_vm_qemu", map[string]interface{}{
+		"name": "router",
+		"network": []interface{}{
+			map[string]interface{}{"model": "virtio", "bridge": "vmbr0"},
+			map[string]interface{}{"model": "e1000", "bridge": "vmbr1"},
+		},
+	})
+	if res.Inputs["net0"] != "virtio,bridge=vmbr0" {
+		t.Errorf("net0: %v", res.Inputs["net0"])
+	}
+	if res.Inputs["net1"] != "e1000,bridge=vmbr1" {
+		t.Errorf("net1: %v", res.Inputs["net1"])
+	}
+}
+
+func TestNormalizeTF_ProxmoxLXC(t *testing.T) {
+	res := normalize("proxmox_lxc", map[string]interface{}{
+		"hostname":    "cache-01",
+		"target_node": "pve",
+		"memory":      float64(512),
+		"swap":        float64(512),
+		"ostemplate":  "local:vztmpl/alpine-3.19.tar.xz",
+		"rootfs": map[string]interface{}{
+			"storage": "local-lvm",
+			"size":    "8G",
+		},
+		"network": map[string]interface{}{
+			"name":   "eth0",
+			"bridge": "vmbr0",
+			"ip":     "dhcp",
+		},
+	})
+
+	if res.Name != "cache-01" {
+		t.Errorf("want name from hostname, got %q", res.Name)
+	}
+	if res.Inputs["rootfs"] != "local-lvm:8" {
+		t.Errorf("rootfs: %v", res.Inputs["rootfs"])
+	}
+	if res.Inputs["net0"] != "name=eth0,bridge=vmbr0,ip=dhcp" {
+		t.Errorf("net0: %v", res.Inputs["net0"])
+	}
+}
+
+func TestNormalizeTF_FlyMachine(t *testing.T) {
+	res := normalize("fly_machine", map[string]interface{}{
+		"name":     "worker",
+		"app":      "my-app",
+		"region":   "syd",
+		"image":    "flyio/worker:v2",
+		"cpus":     float64(2),
+		"memorymb": float64(512),
+		"env":      map[string]interface{}{"MODE": "prod"},
+	})
+
+	if res.Name != "worker" {
+		t.Errorf("name: %q", res.Name)
+	}
+	if res.Inputs["memory"] != float64(512) {
+		t.Errorf("want memorymb renamed to memory, got %v", res.Inputs["memory"])
+	}
+	if res.Inputs["image"] != "flyio/worker:v2" || res.Inputs["region"] != "syd" {
+		t.Errorf("core fields missing: %+v", res.Inputs)
+	}
+}
+
+func TestNormalizeTF_OpenStackInstance(t *testing.T) {
+	res := normalize("openstack_compute_instance_v2", map[string]interface{}{
+		"name":        "app-server",
+		"flavor_name": "m1.small",
+		"image_name":  "ubuntu-22.04",
+		"key_pair":    "deploy-key",
+		"network": []interface{}{
+			map[string]interface{}{"name": "private", "uuid": "abc-123"},
+			map[string]interface{}{"name": "public"},
+		},
+	})
+
+	if res.Name != "app-server" {
+		t.Errorf("name: %q", res.Name)
+	}
+	if res.Inputs["network_id"] != "abc-123" {
+		t.Errorf("want first network uuid as network_id, got %v", res.Inputs["network_id"])
+	}
+	if res.Inputs["network"] != "private" {
+		t.Errorf("network name: %v", res.Inputs["network"])
+	}
+}
+
+func TestNormalizeTF_OpenNebulaVM(t *testing.T) {
+	res := normalize("opennebula_virtual_machine", map[string]interface{}{
+		"name":        "one-vm",
+		"cpu":         float64(1),
+		"memory":      float64(1024),
+		"template_id": float64(7),
+		"disk": map[string]interface{}{
+			"image_id": float64(0), // id 0 is valid in OpenNebula
+			"size":     float64(10240),
+		},
+		"nic": map[string]interface{}{
+			"network_id": float64(3),
+		},
+		"context": map[string]interface{}{"SSH_PUBLIC_KEY": "ssh-ed25519 ..."},
+	})
+
+	if res.Inputs["image_id"] != 0 {
+		t.Errorf("image_id 0 should survive: %v", res.Inputs["image_id"])
+	}
+	if res.Inputs["disk_size"] != 10240 {
+		t.Errorf("disk_size: %v", res.Inputs["disk_size"])
+	}
+	if res.Inputs["network_id"] != 3 {
+		t.Errorf("network_id: %v", res.Inputs["network_id"])
+	}
+	if _, ok := res.Inputs["context"]; !ok {
+		t.Error("context block should be preserved")
+	}
+}
+
+func TestNormalizeTF_UnknownType_PassesThrough(t *testing.T) {
+	attrs := map[string]interface{}{"anything": "goes", "keep": true}
+	res := normalize("some_unmapped_type", attrs)
+	if len(res.Inputs) != 2 {
+		t.Errorf("unmapped types should keep raw inputs, got %+v", res.Inputs)
+	}
+	if res.Name != "raw-name" {
+		t.Errorf("unmapped types should keep original name, got %q", res.Name)
+	}
+}


### PR DESCRIPTION
### Summary

Three engine-level features, stacked on #77 (base branch will retarget to `main` when that merges):

**`gecko burrow` is now real (#69).** The command previously printed hardcoded fake output and never touched a provider or state. It now loads the project, configures providers, validates the resource type, calls the provider's `Import()`, and persists the discovered state under the requested local name — with `--dry-run`, duplicate-ID protection, and state locking. Verified end-to-end: it genuinely dials the provider (connection-refused against a dead endpoint, real field output on success). Also factors the duplicated 60-line provider-configuration switch out of grip/crawl into a shared `registerProviders` helper.

**Drift detection (#70).** New `Engine.Refresh` reads every resource in state back from its provider, compares live values against recorded inputs (restricted to declared fields, so provider-side defaults aren't noise; tolerant of JSON int/float round-trips), marks divergent or missing resources `StatusDrifted`, and persists statuses. `gecko crawl --refresh` runs it before planning and prints field-level drift. This leans directly on the not-found fix from #77 — resources deleted out-of-band are reported as *missing* instead of erroring the refresh.

**Terraform input normalization (#73).** `normalizeTFInputs` now covers `proxmox_vm_qemu`/`proxmox_lxc` (nested network/disk blocks composed into PVE `net0`/`scsi0`/`rootfs` strings), `fly_app`/`fly_machine`/`fly_volume`, `openstack_compute_instance_v2` + network/subnet/secgroup/volume, and `opennebula_virtual_machine`/`virtual_network`/`image` — producing inputs the gecko providers actually consume.

### Notes

- #69's "all providers" is satisfied at the command layer: every provider's `Import()` flows through the same path. Real-API verification exists for Proxmox; the other providers return their fake-client data until #61–65 land.
- Found while testing: `examples/proxmox/main.scute` fails to parse (`export:` inside a spawn block trips the lexer) — pre-existing, not addressed here; worth its own issue.

### Closes

- Closes #69 — gecko burrow (import)
- Closes #70 — drift detection
- Closes #73 — Terraform input normalization

### Test plan

- [x] `go build ./...` / `go vet ./...` pass
- [x] `go test ./...` — 6 new engine refresh tests, 7 new normalization tests, all green
- [x] CLI smoke: burrow dry-run reaches provider and renders real fields; unsupported type rejected; `crawl --refresh` reports drift status before plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)