### PR TITLE
fix: allow keyword-shaped attribute keys in Scute blocks

### DIFF
--- a/internal/lang/parser.go
+++ b/internal/lang/parser.go
@@ -71,6 +71,21 @@ func (p *Parser) check(tt TokenType) bool {
 	return p.cur().Type == tt
 }
 
+// checkFieldKey reports whether the current token can start a "key: value"
+// field. Plain identifiers always can; keyword-shaped names ("export",
+// "from", ...) count only when immediately followed by ':' so structural
+// keywords keep their meaning (#79).
+func (p *Parser) checkFieldKey() bool {
+	t := p.cur() // note: cur() leaves p.pos on the token itself
+	if t.Type == IDENT {
+		return true
+	}
+	if !fieldKeyable(t.Type) {
+		return false
+	}
+	return p.pos+1 < len(p.tokens) && p.tokens[p.pos+1].Type == COLON
+}
+
 func (p *Parser) match(types ...TokenType) bool {
 	for _, tt := range types {
 		if p.cur().Type == tt {
@@ -216,17 +231,20 @@ func (p *Parser) parseSpawn(protected bool) *SpawnBlock {
 			p.expect(COLON)
 			dep := p.parseExpr()
 			b.Needs = append(b.Needs, dep)
-		case IDENT:
-			// Check for key: value or key: \n ... end (sub-block)
-			f := p.parseField()
-			if f != nil {
-				b.Fields = append(b.Fields, f)
-			}
 		case NEWLINE:
 			p.advance()
 		default:
-			p.errorf(t, "unexpected %q inside spawn block", t.Literal)
-			p.advance()
+			// key: value or key: \n ... end (sub-block); keyword-shaped
+			// keys like "export:" are allowed here too
+			if p.checkFieldKey() {
+				f := p.parseField()
+				if f != nil {
+					b.Fields = append(b.Fields, f)
+				}
+			} else {
+				p.errorf(t, "unexpected %q inside spawn block", t.Literal)
+				p.advance()
+			}
 		}
 		p.skipNL()
 	}
@@ -317,7 +335,7 @@ func (p *Parser) parseFieldsUntilEnd() []*Field {
 	var fields []*Field
 	p.skipNL()
 	for !p.check(END) && !p.check(EOF) {
-		if p.check(IDENT) {
+		if p.checkFieldKey() {
 			f := p.parseField()
 			if f != nil {
 				fields = append(fields, f)
@@ -348,11 +366,11 @@ func (p *Parser) parseField() *Field {
 	if p.curRaw().Type == NEWLINE {
 		// Peek ahead — if the next content is a field assignment, treat as sub-block
 		p.skipNL()
-		if p.check(IDENT) || p.check(END) {
+		if p.checkFieldKey() || p.check(END) {
 			// Sub-block
 			sub := &SubBlock{Pos: p.posOf(tok)}
 			for !p.check(END) && !p.check(EOF) {
-				if p.check(IDENT) {
+				if p.checkFieldKey() {
 					sf := p.parseField()
 					if sf != nil {
 						sub.Fields = append(sub.Fields, sf)

--- a/internal/lang/parser_keyword_field_test.go
+++ b/internal/lang/parser_keyword_field_test.go
@@ -1,0 +1,117 @@
+package lang
+
+import (
+	"os"
+	"testing"
+)
+
+func parseOne(t *testing.T, src string) *Program {
+	t.Helper()
+	prog, errs := ParseFile(src, "test.scute")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+	return prog
+}
+
+func findSpawn(t *testing.T, prog *Program) *SpawnBlock {
+	t.Helper()
+	for _, s := range prog.Statements {
+		if b, ok := s.(*SpawnBlock); ok {
+			return b
+		}
+	}
+	t.Fatal("no spawn block found")
+	return nil
+}
+
+func fieldValue(fields []*Field, key string) (Node, bool) {
+	for _, f := range fields {
+		if f.Key == key {
+			return f.Value, true
+		}
+	}
+	return nil, false
+}
+
+// #79: keyword-shaped attribute keys like "export:" must parse inside blocks.
+func TestParse_KeywordFieldKeys_InSpawn(t *testing.T) {
+	prog := parseOne(t, `
+spawn "proxmox:storage" as "gecko-nfs"
+  storage: "gecko-nfs"
+  type:    "nfs"
+  server:  "192.168.1.10"
+  export:  "/mnt/storage"
+  from:    "somewhere"
+  content: "images,rootdir,iso"
+end
+`)
+	b := findSpawn(t, prog)
+	for _, key := range []string{"storage", "type", "server", "export", "from", "content"} {
+		if _, ok := fieldValue(b.Fields, key); !ok {
+			t.Errorf("field %q missing from spawn block: got %d fields", key, len(b.Fields))
+		}
+	}
+}
+
+func TestParse_KeywordFieldKeys_InHabitat(t *testing.T) {
+	prog := parseOne(t, `
+habitat "proxmox"
+  endpoint: "https://pve:8006"
+  export:   "unusual-but-legal"
+end
+`)
+	for _, s := range prog.Statements {
+		if h, ok := s.(*HabitatBlock); ok {
+			if _, found := fieldValue(h.Fields, "export"); !found {
+				t.Errorf("export field missing from habitat: %+v", h.Fields)
+			}
+			return
+		}
+	}
+	t.Fatal("no habitat block found")
+}
+
+func TestParse_KeywordWithoutColon_StillErrors(t *testing.T) {
+	_, errs := ParseFile(`
+spawn "proxmox:vm" as "x"
+  export "not-a-field"
+end
+`, "test.scute")
+	if len(errs) == 0 {
+		t.Fatal("bare keyword without ':' inside spawn should still be an error")
+	}
+}
+
+func TestParse_EndStillTerminatesBlocks(t *testing.T) {
+	prog := parseOne(t, `
+spawn "proxmox:vm" as "x"
+  memory: 2048
+end
+
+spawn "proxmox:vm" as "y"
+  cores: 2
+end
+`)
+	count := 0
+	for _, s := range prog.Statements {
+		if _, ok := s.(*SpawnBlock); ok {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("want 2 spawn blocks, got %d", count)
+	}
+}
+
+// The example project that originally surfaced #79 must parse cleanly.
+func TestParse_ProxmoxExample(t *testing.T) {
+	src, err := os.ReadFile("../../examples/proxmox/main.scute")
+	if err != nil {
+		t.Skipf("example file not available: %v", err)
+	}
+	_, errs := ParseFile(string(src), "main.scute")
+	if len(errs) > 0 {
+		t.Fatalf("examples/proxmox/main.scute should parse: %v", errs)
+	}
+}

--- a/internal/lang/token.go
+++ b/internal/lang/token.go
@@ -186,6 +186,26 @@ func LookupIdent(ident string) TokenType {
 	return IDENT
 }
 
+// keywordTokenTypes is the set of token types produced by the keywords table.
+var keywordTokenTypes = func() map[TokenType]bool {
+	m := make(map[TokenType]bool, len(keywords))
+	for _, tt := range keywords {
+		m[tt] = true
+	}
+	return m
+}()
+
+// fieldKeyable reports whether a keyword token may double as a field key
+// (e.g. "export:" or "from:" as attribute names inside a block). Literals
+// and the block terminator keep their structural meaning.
+func fieldKeyable(tt TokenType) bool {
+	switch tt {
+	case END, BOOL, NULL:
+		return false
+	}
+	return keywordTokenTypes[tt]
+}
+
 // Token is a lexical unit with position info
 type Token struct {
 	Type    TokenType


### PR DESCRIPTION
### Summary

The Scute lexer turns words like `export`, `from`, and `snack` into keyword tokens unconditionally, so they couldn't be used as attribute keys inside spawn/habitat/other blocks — which broke `examples/proxmox/main.scute` entirely (`export:` is a legitimate NFS storage option for `proxmox:storage`).

The parser now accepts a keyword as a field key when it is **immediately followed by `:`**, via a `checkFieldKey()` helper used in spawn bodies, `parseFieldsUntilEnd` (habitat/territory/store/camouflage), and sub-blocks. Bare keywords and the `end` terminator keep their structural meaning, as do `true`/`false`/`null` literals.

### Tests

- 5 new parser tests, including one that parses the real `examples/proxmox/main.scute`
- Verified `gecko crawl` in `examples/proxmox` now loads and plans all 5 resources (previously failed with 3 lexer errors)

### Closes

- Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)